### PR TITLE
Make app name in About window translatable

### DIFF
--- a/data/resources/about.ui
+++ b/data/resources/about.ui
@@ -7,7 +7,7 @@
     <property name="modal">True</property>
     <property name="destroy_with_parent">True</property>
     <property name="type_hint">dialog</property>
-    <property name="program_name">Dialect</property>
+    <property name="program_name" translatable="yes">Dialect</property>
     <property name="copyright" translatable="yes">Copyright 2020-2021 The Dialect Authors</property>
     <property name="comments" translatable="yes">A translation app for GNOME.</property>
     <property name="website">https://github.com/dialect-app/dialect</property>


### PR DESCRIPTION
If you made `about.ui` with Glade, you must mark the application name as translatable manually from a text editor. Otherwise, the translated application name will not be reflected here.