### PR TITLE
fix(translators/google): propagate api exceptions

### DIFF
--- a/dialect/translators/gtrans.py
+++ b/dialect/translators/gtrans.py
@@ -30,7 +30,7 @@ class Translator(TranslatorBase):
     }
 
     def __init__(self, **kwargs):
-        self._translator = GoogleTranslator()
+        self._translator = GoogleTranslator(raise_exception=True)
 
     def detect(self, src_text):
         try:


### PR DESCRIPTION
The default is `False` (https://github.com/ssut/py-googletrans/blob/d15c94f176463b2ce6199a42a1c517690366977f/googletrans/constants.py#L186). Shows "Translation failed. Please check for network issues" when the API returns `429 Too Many Requests`. While the message is a bit misleading (there are no network errors), it's an improvement over the current situation (the input test is shown as the output and no errors are reported to the user).

Closes https://github.com/dialect-app/dialect/issues/151.