### PR TITLE
Port translators settings to GSettings

### DIFF
--- a/data/com.github.gi_lom.dialect.gschema.xml.in
+++ b/data/com.github.gi_lom.dialect.gschema.xml.in
@@ -59,5 +59,41 @@
         <description>DEPRECATED: This key is deprecated and normally ignored.</description>
         <default>""</default>
     </key>
+
+    <child name="translators" schema="@app-id@.TranslatorsList" />
+  </schema>
+
+  <!-- Settings list schema -->
+  <schema id="@app-id@.SettingsList">
+    <key name="list" type="as">
+      <default>[]</default>
+    </key>
+    <key name="active" type="s">
+      <default>""</default>
+    </key>
+  </schema>
+
+  <!-- Translators list schema -->
+  <schema id="@app-id@.TranslatorsList" extends="@app-id@.SettingsList">
+    <override name="active">"google"</override>
+  </schema>
+
+  <!-- Translator schema -->
+  <schema id="@app-id@.translator">
+    <key type="b" name="init">
+        <default>false</default>
+    </key>
+    <key type="as" name="src-langs">
+        <default>[]</default>
+    </key>
+    <key type="as" name="dest-langs">
+        <default>[]</default>
+    </key>
+    <key type="s" name="instance-url">
+        <default>""</default>
+    </key>
+    <key type="s" name="api-key">
+        <default>""</default>
+    </key>
   </schema>
 </schemalist>

--- a/data/com.github.gi_lom.dialect.gschema.xml.in
+++ b/data/com.github.gi_lom.dialect.gschema.xml.in
@@ -26,10 +26,14 @@
         <default>-1</default>
     </key>
     <key type="s" name="backend-name">
-        <default>"google"</default>
+        <!-- Deprecated option -->
+        <description>DEPRECATED: This key is deprecated and normally ignored.</description>
+        <default>""</default>
     </key>
     <key type="s" name="backend-settings">
-        <default>"{}"</default>
+        <!-- Deprecated option -->
+        <description>DEPRECATED: This key is deprecated and normally ignored.</description>
+        <default>""</default>
     </key>
     <key type="s" name="tts-name">
         <default>"google"</default>

--- a/dialect/preferences.py
+++ b/dialect/preferences.py
@@ -144,8 +144,8 @@ class DialectPreferencesWindow(Adw.PreferencesWindow):
         if key == 'backend-settings':
             if TRANSLATORS[backend].supported_features['change-instance']:
                 # Update backend
-                Settings.get().reset_src_langs(backend)
-                Settings.get().reset_dest_langs(backend)
+                Settings.get().reset_src_langs()
+                Settings.get().reset_dest_langs()
                 self.parent.change_backends(backend)
 
     def _toggle_dark_mode(self, switch, _active):
@@ -213,7 +213,7 @@ class DialectPreferencesWindow(Adw.PreferencesWindow):
 
     def _on_reset_backend_instance(self, _button):
         backend = Settings.get().active_translator
-        Settings.get().reset_instance_url(backend)
+        Settings.get().reset_instance_url()
         self.backend_instance_label.set_label(Settings.get().instance_url)
         self.backend_instance_stack.set_visible_child_name('view')
         Gtk.StyleContext.remove_class(self.backend_instance.get_style_context(), 'error')

--- a/dialect/search_provider/search_provider.in
+++ b/dialect/search_provider/search_provider.in
@@ -124,8 +124,8 @@ class TranslateService(dbus.service.Object):
 
         # set dest_language to last used language and src_language to auto detection
         src_language = 'auto'
-        src_language_saved = Settings.get().get_src_langs(self.translator.name)[0]
-        dest_language = Settings.get().get_dest_langs(self.translator.name)[0]
+        src_language_saved = Settings.get().src_langs[0]
+        dest_language = Settings.get().dest_langs[0]
 
         if self.trans_queue:
             self.trans_queue.pop(0)
@@ -189,10 +189,10 @@ class TranslateService(dbus.service.Object):
         return Settings.get().live_translation
 
     def _get_translator(self):
-        backend = Settings.get().backend
+        backend = Settings.get().active_translator
         if TRANSLATORS[backend].supported_features['change-instance']:
             translator = TRANSLATORS[backend](
-                base_url=Settings.get().get_instance_url(TRANSLATORS[backend].name)
+                base_url=Settings.get().instance_url
             )
         else:
             translator = TRANSLATORS[backend]()

--- a/dialect/settings.py
+++ b/dialect/settings.py
@@ -25,8 +25,6 @@ class Settings(Gio.Settings):
 
     def __init__(self):
         Gio.Settings.__init__(self)
-        self.init_translators_settings()
-        self.migrate_legacy()
 
     @staticmethod
     def new():
@@ -40,6 +38,8 @@ class Settings(Gio.Settings):
         """Return an active instance of Settings."""
         if Settings.instance is None:
             Settings.instance = Settings.new()
+            Settings.instance.init_translators_settings()
+            Settings.instance.migrate_legacy()
 
         return Settings.instance
 

--- a/dialect/settings.py
+++ b/dialect/settings.py
@@ -64,7 +64,13 @@ class Settings(Gio.Settings):
 
     @property
     def active_translator(self):
-        return self.get_child('translators').get_string('active')
+        value = self.get_child('translators').get_string('active')
+
+        if check_backend_availability(value):
+            return value
+
+        self.active_translator = get_fallback_backend_name()
+        return get_fallback_backend_name()
 
     @active_translator.setter
     def active_translator(self, translator):
@@ -99,6 +105,9 @@ class Settings(Gio.Settings):
     def src_langs(self, src_langs):
         self.get_translator_settings().set_strv('src-langs', src_langs)
 
+    def reset_src_langs(self):
+        self.src_langs = TRANSLATORS[self.active_translator].src_langs
+
     @property
     def dest_langs(self):
         return self.get_translator_settings().get_strv('dest-langs')
@@ -106,6 +115,9 @@ class Settings(Gio.Settings):
     @dest_langs.setter
     def dest_langs(self, dest_langs):
         self.get_translator_settings().set_strv('dest-langs', dest_langs)
+    
+    def reset_dest_langs(self):
+        self.dest_langs = TRANSLATORS[self.active_translator].dest_langs
 
     @property
     def instance_url(self):
@@ -116,6 +128,9 @@ class Settings(Gio.Settings):
         self.get_translator_settings().set_string('instance-url', url)
         self.save_translator_settings()
 
+    def reset_instance_url(self):
+        self.instance_url = TRANSLATORS[self.active_translator].instance_url
+
     @property
     def api_key(self):
         return self.get_translator_settings().get_string('api-key')
@@ -124,6 +139,9 @@ class Settings(Gio.Settings):
     def api_key(self, api_key):
         self.get_translator_settings().set_string('api-key', api_key)
         self.save_translator_settings()
+
+    def reset_api_key(self):
+        self.api_key = TRANSLATORS[self.active_translator].api_key
 
     @property
     def window_size(self):
@@ -255,10 +273,6 @@ class Settings(Gio.Settings):
         self._delete_str_key(f'{backend}-instance')  # Set deprecated key to unused state.
         self._set_backend_setting(backend, 'instance-url', instance_url)
 
-    def reset_instance_url(self, backend):
-        self._delete_str_key(f'{backend}-instance')  # Set deprecated key to unused state.
-        self.instance_url = TRANSLATORS[self.active_translator].instance_url
-
     def get_dest_langs(self, backend):
         # Dialect 1.2.0 and below used separate keys for each
         # backend-specific setting.
@@ -277,10 +291,6 @@ class Settings(Gio.Settings):
         self._delete_arr_key(f'{backend}-dest-langs')  # Set deprecated key to unused state.
         self._set_backend_setting(backend, 'dest-langs', langs)
 
-    def reset_dest_langs(self, backend):
-        self._delete_arr_key(f'{backend}-dest-langs')  # Set deprecated key to unused state.
-        self.dest_langs = TRANSLATORS[backend].dest_langs
-
     def get_src_langs(self, backend):
         # Dialect 1.2.0 and below used separate keys for each
         # backend-specific setting.
@@ -298,10 +308,6 @@ class Settings(Gio.Settings):
     def set_src_langs(self, backend, langs):
         self._delete_arr_key(f'{backend}-src-langs')  # Set deprecated key to unused state.
         self._set_backend_setting(backend, 'src-langs', langs)
-
-    def reset_src_langs(self, backend):
-        self._delete_arr_key(f'{backend}-src-langs')  # Set deprecated key to unused state.
-        self.src_langs = TRANSLATORS[backend].src_langs
 
     @property
     def backend_settings(self):

--- a/dialect/settings.py
+++ b/dialect/settings.py
@@ -31,6 +31,8 @@ class Settings(Gio.Settings):
         """Create a new instance of Settings."""
         g_settings = Gio.Settings.new(APP_ID)
         g_settings.__class__ = Settings
+        g_settings.init_translators_settings()
+        g_settings.migrate_legacy()
         return g_settings
 
     @staticmethod
@@ -38,9 +40,6 @@ class Settings(Gio.Settings):
         """Return an active instance of Settings."""
         if Settings.instance is None:
             Settings.instance = Settings.new()
-            Settings.instance.init_translators_settings()
-            Settings.instance.migrate_legacy()
-
         return Settings.instance
 
     def init_translators_settings(self):

--- a/dialect/translators/basetrans.py
+++ b/dialect/translators/basetrans.py
@@ -14,6 +14,7 @@ class TranslatorBase:
         'suggestions': False,
     }
     instance_url = ''
+    api_key = ''
     src_langs = ['en', 'fr', 'es', 'de']
     dest_langs = ['fr', 'es', 'de', 'en']
 

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -153,7 +153,7 @@ class DialectWindow(Adw.ApplicationWindow):
         self.retry_backend_btn.connect('clicked', self.retry_load_translator)
         threading.Thread(
             target=self.load_translator,
-            args=[Settings.get().backend, True],
+            args=[Settings.get().active_translator, True],
             daemon=True
         ).start()
         # Get languages available for speech
@@ -255,14 +255,14 @@ class DialectWindow(Adw.ApplicationWindow):
             # Translator object
             if TRANSLATORS[backend].supported_features['change-instance']:
                 self.translator = TRANSLATORS[backend](
-                    base_url=Settings.get().get_instance_url(TRANSLATORS[backend].name)
+                    base_url=Settings.get().instance_url
                 )
             else:
                 self.translator = TRANSLATORS[backend]()
 
             # Get saved languages
-            self.src_langs = Settings.get().get_src_langs(self.translator.name)
-            self.dest_langs = Settings.get().get_dest_langs(self.translator.name)
+            self.src_langs = Settings.get().src_langs
+            self.dest_langs = Settings.get().dest_langs
 
             # Update UI
             GLib.idle_add(update_ui)
@@ -289,7 +289,7 @@ class DialectWindow(Adw.ApplicationWindow):
     def retry_load_translator(self, _button):
         threading.Thread(
             target=self.load_translator,
-            args=[Settings.get().backend],
+            args=[Settings.get().active_translator],
             daemon=True
         ).start()
 
@@ -473,8 +473,9 @@ class DialectWindow(Adw.ApplicationWindow):
             size = self.get_default_size()
             Settings.get().window_size = (size.width, size.height)
         if self.translator is not None:
-            Settings.get().set_src_langs(self.translator.name, self.src_langs)
-            Settings.get().set_dest_langs(self.translator.name, self.dest_langs)
+            Settings.get().src_langs = self.src_langs
+            Settings.get().dest_langs = self.dest_langs
+            Settings.get().save_translator_settings()
 
     def send_notification(self, text, type='warning', timeout=5):
         """

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -236,11 +236,11 @@ class DialectWindow(Adw.ApplicationWindow):
             # Update selected langs
             self.src_lang_selector.set_property(
                 'selected',
-                'auto' if Settings.get().src_auto else self._fix_cases(self.src_langs[0])
+                'auto' if Settings.get().src_auto else self.src_langs[0]
             )
             self.dest_lang_selector.set_property(
                 'selected',
-                self._fix_cases(self.dest_langs[0])
+                self.dest_langs[0]
             )
 
             self.no_retranslate = False
@@ -541,8 +541,8 @@ class DialectWindow(Adw.ApplicationWindow):
             self.dest_voice_spinner.stop()
 
     def on_src_lang_changed(self, _obj, _param):
-        code = self._fix_cases(self.src_lang_selector.get_property('selected'))
-        dest_code = self._fix_cases(self.dest_lang_selector.get_property('selected'))
+        code = self.src_lang_selector.get_property('selected')
+        dest_code = self.dest_lang_selector.get_property('selected')
         src_text = self.src_buffer.get_text(
             self.src_buffer.get_start_iter(),
             self.src_buffer.get_end_iter(),
@@ -550,10 +550,8 @@ class DialectWindow(Adw.ApplicationWindow):
         )
 
         if code == dest_code:
-            code = self._fix_cases(
-                self.dest_langs[1] if code == self.src_langs[0] else dest_code
-            )
-            self.dest_lang_selector.set_property('selected', self._fix_cases(self.src_langs[0]))
+            code = self.dest_langs[1] if code == self.src_langs[0] else dest_code
+            self.dest_lang_selector.set_property('selected', self.src_langs[0])
 
         # Disable or enable listen function.
         if self.tts_langs and Settings.get().tts != '':
@@ -580,7 +578,6 @@ class DialectWindow(Adw.ApplicationWindow):
         self.src_lang_selector.clear_recent()
         self.src_lang_selector.insert_recent('auto', _('Auto'))
         for code in self.src_langs:
-            code = self._fix_cases(code)
             self.src_lang_selector.insert_recent(code, get_lang_name(code))
 
         # Refresh list
@@ -591,8 +588,8 @@ class DialectWindow(Adw.ApplicationWindow):
             self.translation(None)
 
     def on_dest_lang_changed(self, _obj, _param):
-        code = self._fix_cases(self.dest_lang_selector.get_property('selected'))
-        src_code = self._fix_cases(self.src_lang_selector.get_property('selected'))
+        code = self.dest_lang_selector.get_property('selected')
+        src_code = self.src_lang_selector.get_property('selected')
         dest_text = self.dest_buffer.get_text(
             self.dest_buffer.get_start_iter(),
             self.dest_buffer.get_end_iter(),
@@ -600,8 +597,7 @@ class DialectWindow(Adw.ApplicationWindow):
         )
 
         if code == src_code:
-            code = self._fix_cases(src_code)
-            self.src_lang_selector.set_property('selected', self._fix_cases(self.dest_langs[0]))
+            self.src_lang_selector.set_property('selected', self.dest_langs[0])
 
         # Disable or enable listen function.
         if self.tts_langs and Settings.get().tts != '':
@@ -624,7 +620,6 @@ class DialectWindow(Adw.ApplicationWindow):
         # Rewrite recent langs
         self.dest_lang_selector.clear_recent()
         for code in self.dest_langs:
-            code = self._fix_cases(code)
             self.dest_lang_selector.insert_recent(code, get_lang_name(code))
 
         # Refresh list
@@ -1127,7 +1122,3 @@ class DialectWindow(Adw.ApplicationWindow):
             GLib.idle_add(on_trans_success)
         GLib.idle_add(on_trans_done)
         self.active_thread = None
-
-    @staticmethod
-    def _fix_cases(code):
-        return code.replace('cn', 'CN').replace('tw', 'TW')


### PR DESCRIPTION
TODO:
- [x] Clenup and remove old settings functions
- [x] Update `reset_` functions
- [x] Implement migrations (IMO we should only migrate `backend-name` and `instance-url`. We aren't dealing with sensitive data :P)
