### PR TITLE
AdwToasts for in-app notifications

### DIFF
--- a/data/resources/window.ui
+++ b/data/resources/window.ui
@@ -350,7 +350,7 @@
                                     <child>
                                       <object class="GtkButton" id="translate_btn">
                                         <property name="label" translatable="yes">Translate</property>
-                                        <property name="sensitive">False</property>
+                                        <property name="action-name">win.translation</property>
                                         <style>
                                           <class name="suggested-action"/>
                                         </style>

--- a/data/resources/window.ui
+++ b/data/resources/window.ui
@@ -212,7 +212,7 @@
                   </object>
                 </child>
                 <child>
-                  <object class="GtkOverlay">
+                  <object class="AdwToastOverlay" id="toast_overlay">
                     <property name="vexpand">True</property>
                     <child>
                       <object class="GtkBox">
@@ -564,34 +564,6 @@
                                 </style>
                               </object>
                             </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child type="overlay">
-                      <object class="GtkRevealer" id="notification_revealer">
-                        <property name="halign">center</property>
-                        <property name="valign">start</property>
-                        <property name="transition-type">none</property>
-                        <child>
-                          <object class="GtkBox" id="notification_box">
-                            <property name="halign">start</property>
-                            <property name="valign">center</property>
-                            <property name="spacing">12</property>
-                            <child>
-                              <object class="GtkImage" id="notification_icon">
-                                <property name="icon-name">dialog-warning-symbolic</property>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkLabel" id="notification_label">
-                                <property name="halign">start</property>
-                                <property name="label" translatable="yes">No network connection detected.</property>
-                              </object>
-                            </child>
-                            <style>
-                              <class name="app-notification"/>
-                            </style>
                           </object>
                         </child>
                       </object>

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -490,13 +490,14 @@ class DialectWindow(Adw.ApplicationWindow):
             Settings.get().dest_langs = self.dest_langs
             Settings.get().save_translator_settings()
 
-    def send_notification(self, text, queue=False, action=None):
+    def send_notification(self, text, queue=False, action=None, timeout=5, priority=Adw.ToastPriority.NORMAL):
         """
         Display an in-app notification.
 
         Args:
             text (str): The text or message of the notification.
             queue (bool, optional): If True, the notification will be queued.
+            action (dict, optional): A dict containing the action to be called.
         """
         if not queue and self.toast is not None:
             self.toast.dismiss()
@@ -504,6 +505,8 @@ class DialectWindow(Adw.ApplicationWindow):
         if action is not None:
             self.toast.set_button_label(action['label'])
             self.toast.set_action_name(action['name'])
+        self.toast.set_timeout(timeout)
+        self.toast.set_priority(priority)
         self.toast_overlay.add_toast(self.toast)
 
     def toggle_voice_spinner(self, active=True):

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -917,15 +917,13 @@ class DialectWindow(Adw.ApplicationWindow):
 
     def user_action_ended(self, buffer):
         # If the text is over the highest number of characters allowed, it is truncated.
-        # This is done for avoiding exceeding the limit imposed by Google.
+        # This is done for avoiding exceeding the limit imposed by translation services.
         if buffer.get_char_count() >= MAX_LENGTH:
             self.send_notification(_('5000 characters limit reached!'))
-            src_text = buffer.get_text(
-                buffer.get_start_iter(),
-                buffer.get_end_iter(),
-                True
+            buffer.delete(
+                buffer.get_iter_at_offset(MAX_LENGTH),
+                buffer.get_end_iter()
             )
-            self.src_buffer.set_text(src_text[:MAX_LENGTH])
         self.char_counter.set_text(f'{str(buffer.get_char_count())}/{MAX_LENGTH}')
         if Settings.get().live_translation:
             self.translation()


### PR DESCRIPTION
In return, we lose some functionality and control. We also introduce some warnings and errors that do not effect the functioning of the application.

What we gain:
- Beautifully animated toasts in place of our poorly done in-app notifications system.
- Some cleanup because we get to delete code.

What we lose:
- Icons in notifications (success, failure, warning, etc)
- ~Control over timeout~ AdwToast now has support for setting timeouts.

Other issues:
- Warnings like:
```
(dialect:2): Adwaita-CRITICAL **: Trying to dismiss the toast '5000 characters limit reached!', but it isn't in an AdwToastOverlay yet
```
These do not seem to impact the functioning of the application itself.