### PR TITLE
window: Simplify translator object creation

### DIFF
--- a/dialect/search_provider/search_provider.in
+++ b/dialect/search_provider/search_provider.in
@@ -157,14 +157,12 @@ class TranslateService(dbus.service.Object):
 
     def _get_translator(self):
         backend = Settings.get().active_translator
-        if TRANSLATORS[backend].supported_features['change-instance']:
-            translator = TRANSLATORS[backend](
-                self._on_loaded,
-                base_url=Settings.get().instance_url,
-                api_key=Settings.get().api_key
-            )
-        else:
-            translator = TRANSLATORS[backend]()
+        translator = TRANSLATORS[backend](
+            self._on_loaded,
+            base_url=Settings.get().instance_url,
+            api_key=Settings.get().api_key
+        )
+        if not TRANSLATORS[backend].supported_features['change-instance']:
             self.loaded = True
         return translator
 

--- a/dialect/settings.py
+++ b/dialect/settings.py
@@ -2,8 +2,6 @@
 # Copyright 2021-2022 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import json
-
 from gi.repository import Gio, GLib
 
 from dialect.define import APP_ID

--- a/dialect/translators/libretrans.py
+++ b/dialect/translators/libretrans.py
@@ -29,7 +29,7 @@ class Translator(TranslatorBase):
         'api-key-supported': False,
         'api-key-required': False,
     }
-    instance_url = 'translate.api.skitzen.com'
+    instance_url = 'libretranslate.pussthecat.org'
     api_key = ''
 
     validation_path = '/spec'

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -268,14 +268,12 @@ class DialectWindow(Adw.ApplicationWindow):
         self.main_stack.set_visible_child_name('loading')
 
         # Translator object
-        if TRANSLATORS[backend].supported_features['change-instance']:
-            self.translator = TRANSLATORS[backend](
-                callback=on_loaded,
-                base_url=Settings.get().instance_url,
-                api_key=Settings.get().api_key,
-            )
-        else:
-            self.translator = TRANSLATORS[backend]()
+        self.translator = TRANSLATORS[backend](
+            callback=on_loaded,
+            base_url=Settings.get().instance_url,
+            api_key=Settings.get().api_key,
+        )
+        if not TRANSLATORS[backend].supported_features['change-instance']:
             on_loaded(True)  # Assume successful loading.
 
         if launch:


### PR DESCRIPTION
As discussed previously, this is intended to simplify the translator object creation. But there's a problem. Trying to access Settings from the translators would cause cyclic dependency. And even when ignoring that, we can't avoid manually calling `on_loaded`. This is because it needs to be called after the `__init__()`.

About the **change default instance of LibreTranslate**. So, we keep the dance going... What do you think about just defaulting to libretranslate.com?