### PR TITLE
Pin blueprint-compiler to v0.4.0 and fix an upcoming error

### DIFF
--- a/build-aux/flatpak/app.drey.Dialect.Devel.json
+++ b/build-aux/flatpak/app.drey.Dialect.Devel.json
@@ -25,7 +25,8 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.gnome.org/jwestman/blueprint-compiler",
-                    "branch": "main"
+                    "tag": "v0.4.0",
+                    "commit": "75a6d95988736ec0471d22ceb07579c0cedac2ad"
                 }
             ]
         },

--- a/data/resources/window.blp
+++ b/data/resources/window.blp
@@ -38,8 +38,8 @@ menu app-menu {
 }
 
 template DialectWindow : Adw.ApplicationWindow {
-  default-width: "800";
-  default-height: "300";
+  default-width: 800;
+  default-height: 300;
   focus-widget: src_text;
 
   Stack main_stack {

--- a/subprojects/blueprint-compiler.wrap
+++ b/subprojects/blueprint-compiler.wrap
@@ -1,7 +1,7 @@
 [wrap-git]
 directory = blueprint-compiler
 url = https://gitlab.gnome.org/jwestman/blueprint-compiler.git
-revision = main
+revision = v0.4.0
 depth = 1
 
 [provide]


### PR DESCRIPTION
Fixes #285.