### PR TITLE
Fix typos

### DIFF
--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -138,7 +138,7 @@
         <ul>
           <li>Added a shortcuts window</li>
           <li>Added Indonesian translation</li>
-          <li>Added Portugese (BR) translation</li>
+          <li>Added Portuguese (BR) translation</li>
           <li>Fixed several bugs</li>
         </ul>
       </description>

--- a/dialect/lang_selector.py
+++ b/dialect/lang_selector.py
@@ -25,7 +25,7 @@ class DialectLangSelector(Gtk.Popover):
     separator = Gtk.Template.Child()
     lang_list = Gtk.Template.Child()
 
-    # Propeties
+    # Properties
     selected = GObject.Property(type=str)  # Key of the selected lang
 
     def __init__(self, **kwargs):
@@ -54,8 +54,8 @@ class DialectLangSelector(Gtk.Popover):
         self.lang_model = Gio.ListStore.new(LangObject)
         self.filter = Gtk.CustomFilter()
         self.filter.set_filter_func(self._filter_func)
-        fitler_model = Gtk.FilterListModel.new(self.lang_model, self.filter)
-        self.lang_list.bind_model(fitler_model, self._create_lang_row)
+        filter_model = Gtk.FilterListModel.new(self.lang_model, self.filter)
+        self.lang_list.bind_model(filter_model, self._create_lang_row)
 
     def get_selected(self):
         return self.get_property('selected')

--- a/dialect/settings.py
+++ b/dialect/settings.py
@@ -40,7 +40,7 @@ class Settings(Gio.Settings):
         return Settings.instance
 
     def init_translators_settings(self):
-        """Intialize translators settings with its default values."""
+        """Initialize translators settings with its default values."""
         self.translators_list = list(TRANSLATORS.keys())
         for name, instance in TRANSLATORS.items():
             settings = self.get_translator_settings(name)

--- a/dialect/theme_switcher.py
+++ b/dialect/theme_switcher.py
@@ -3,7 +3,7 @@
 # Copyright 2022 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# Code modifed from Apostrophe
+# Code modified from Apostrophe
 # https://gitlab.gnome.org/World/apostrophe/-/blob/main/apostrophe/theme_switcher.py
 
 from gi.repository import Adw, Gio, GObject, Gtk 

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -104,7 +104,7 @@ class DialectWindow(Adw.ApplicationWindow):
 
     mobile_mode = False  # UI mode
 
-    # Propeties
+    # Properties
     backend_loading = GObject.Property(type=bool, default=False)
 
     def __init__(self, text, langs, **kwargs):
@@ -373,7 +373,7 @@ class DialectWindow(Adw.ApplicationWindow):
         self.dest_voice_btn.set_child(self.dest_voice_warning)
         self.dest_voice_spinner.stop()
 
-        tooltip_text = _('A network issue has occured. Retry?')
+        tooltip_text = _('A network issue has occurred. Retry?')
         self.src_voice_btn.set_tooltip_text(tooltip_text)
         self.dest_voice_btn.set_tooltip_text(tooltip_text)
 
@@ -386,7 +386,7 @@ class DialectWindow(Adw.ApplicationWindow):
             action = None
 
         self.send_notification(
-            _('A network issue has occured. Please try again.'),
+            _('A network issue has occurred. Please try again.'),
             action=action
         )
 


### PR DESCRIPTION
Found via `codespell -S subprojects,po,builddir`

Not familiar on how to make changes to `po` folder, hence skip it.