### PR TITLE
Increase contrast in gnome software banner

### DIFF
--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -32,6 +32,10 @@
 
   <launchable type="desktop-id">@app-id@.desktop</launchable>
   <translation type="gettext">dialect</translation>
+  
+  <custom>
+    <value key="GnomeSoftware::key-colors">[(108, 236, 156), (0, 0, 0)]</value>
+  </custom>
 
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
![dialect banner](https://github.com/dialect-app/dialect/assets/44558032/87c2d0c4-4d1f-46a6-9a49-bef7ee470050)
