### PR TITLE
chore(i18n): Mark release descriptions as untranslatable

### DIFF
--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -50,7 +50,7 @@
   </screenshots>
   <releases>
     <release version="2.1.1" date="2022-10-22">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Updated translations</li>
           <li>Fixed minor bugs</li>
@@ -58,7 +58,7 @@
       </description>
     </release>
     <release version="2.1.0" date="2022-10-18">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Update to use libadwaita 1.2 widgets</li>
           <li>Updated translations</li>
@@ -67,7 +67,7 @@
       </description>
     </release>
     <release version="2.0.2" date="2022-07-17">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Fixed responsive implementation</li>
           <li>Fixed small stylings</li>
@@ -76,14 +76,14 @@
       </description>
     </release>
     <release version="2.0.1" date="2022-07-14">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Fixed an issue with scale factor</li>
         </ul>
       </description>
     </release>
     <release version="2.0.0" date="2022-07-13">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Ported to GTK4 and libadwaita</li>
           <li>New in-app color scheme switcher</li>
@@ -101,14 +101,14 @@
       </description>
     </release>
     <release version="1.4.1" date="2021-10-20">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Fix shortcut bug</li>
         </ul>
       </description>
     </release>
     <release version="1.4.0" date="2021-10-18">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added accels for most actions</li>
           <li>Added localized language names</li>
@@ -118,7 +118,7 @@
       </description>
     </release>
     <release version="1.3.0" date="2021-05-07">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Backend refactor</li>
           <li>Added option to disable Google TTS</li>
@@ -128,7 +128,7 @@
       </description>
     </release>
     <release version="1.2.0" date="2021-03-08">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Switch to a new icon</li>
           <li>Added LibreTranslate backend</li>
@@ -140,7 +140,7 @@
       </description>
     </release>
     <release version="1.1.1" date="2020-12-08">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added a shortcuts window</li>
           <li>Added Indonesian translation</li>
@@ -150,7 +150,7 @@
       </description>
     </release>
     <release version="1.1.0" date="2020-10-30">
-      <description>
+      <description translatable="no">
         <ul>
           <li>Added a search provider for GNOME</li>
           <li>Added support for "Did you mean" suggestions</li>
@@ -167,7 +167,7 @@
       </description>
     </release>
     <release version="1.0.0" date="2020-10-14">
-      <description>
+      <description translatable="no">
         <p>Initial release.</p>
       </description>
     </release>


### PR DESCRIPTION
GNOME automatically excludes release descriptions on Damned Lies (GNOME Translation Platform). It's a good practice to follow the GNOME way.

This can streamline the translation process, allowing translators to focus their efforts on more critical and user-facing aspects of the application.