### PR TITLE
appdata: add vcs-browser and translate support

### DIFF
--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -27,6 +27,7 @@
   <url type="homepage">https://apps.gnome.org/app/app.drey.Dialect/</url>
   <url type="bugtracker">https://github.com/dialect-app/dialect/issues/</url>
   <url type="translate">https://hosted.weblate.org/engage/dialect/</url>
+  <url type="vcs-browser">https://github.com/dialect-app/dialect/</url>
   <developer_name>The Dialect Authors</developer_name>
   <content_rating type="oars-1.1" />
 


### PR DESCRIPTION
These urls are visible on Flathub and GNOME Control Center.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url