### PR TITLE
appdata: Update GNOME Circle URL

### DIFF
--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -24,7 +24,7 @@
       <li>Clipboard buttons</li>
     </ul>
   </description>
-  <url type="homepage">https://apps.gnome.org/app/app.drey.Dialect/</url>
+  <url type="homepage">https://apps.gnome.org/Dialect/</url>
   <url type="bugtracker">https://github.com/dialect-app/dialect/issues/</url>
   <url type="translate">https://hosted.weblate.org/engage/dialect/</url>
   <url type="vcs-browser">https://github.com/dialect-app/dialect/</url>


### PR DESCRIPTION
Use the new simplified URL for apps.gnome.org.