### PR TITLE
Add shortcuts to select languages

### DIFF
--- a/data/resources/shortcuts.blp
+++ b/data/resources/shortcuts.blp
@@ -22,6 +22,16 @@ template $DialectShortcutsWindow : ShortcutsWindow {
         action-name: "win.switch";
       }
 
+      ShortcutsShortcut from_shortcut {
+        title: C_("shortcuts window", "Select source language");
+        action-name: "win.from";
+      }
+
+      ShortcutsShortcut to_shortcut {
+        title: C_("shortcuts window", "Select destination language");
+        action-name: "win.to";
+      }
+
       ShortcutsShortcut {
         title: C_("shortcuts window", "Clear source text");
         action-name: "win.clear";

--- a/dialect/main.py
+++ b/dialect/main.py
@@ -124,6 +124,8 @@ class Dialect(Adw.Application):
         self.set_accels_for_action('win.back', ['<Alt>Left'])
         self.set_accels_for_action('win.forward', ['<Alt>Right'])
         self.set_accels_for_action('win.switch', ['<Primary>S'])
+        self.set_accels_for_action('win.from', ['<Primary>F'])
+        self.set_accels_for_action('win.to', ['<Primary>T'])
         self.set_accels_for_action('win.clear', ['<Primary>D'])
         self.set_accels_for_action('win.paste', ['<Primary><Shift>V'])
         self.set_accels_for_action('win.copy', ['<Primary><Shift>C'])

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -1,6 +1,7 @@
 # Copyright 2020 gi-lom
 # Copyright 2020-2022 Mufeed Ali
 # Copyright 2020-2022 Rafael Mardojai CM
+# Copyright 2023 Libretto
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -142,6 +143,14 @@ class DialectWindow(Adw.ApplicationWindow):
         switch_action = Gio.SimpleAction.new('switch', None)
         switch_action.connect('activate', self.ui_switch)
         self.add_action(switch_action)
+
+        from_action = Gio.SimpleAction.new('from', None)
+        from_action.connect('activate', self.ui_from)
+        self.add_action(from_action)
+
+        to_action = Gio.SimpleAction.new('to', None)
+        to_action.connect('activate', self.ui_to)
+        self.add_action(to_action)
 
         clear_action = Gio.SimpleAction.new('clear', None)
         clear_action.props.enabled = False
@@ -762,6 +771,12 @@ class DialectWindow(Adw.ApplicationWindow):
 
         # Switch all
         self.switch_all(src_language, dest_language, src_text, dest_text)
+
+    def ui_from(self, _action, _param):
+        self.src_lang_selector.button.popup()
+
+    def ui_to(self, _action, _param):
+        self.dest_lang_selector.button.popup()
 
     def ui_clear(self, _action, _param):
         self.src_buffer.props.text = ''


### PR DESCRIPTION
This adds Ctrl-F to select the From language and Ctrl-T to select the To language, making Dialect fully usable without the mouse.
As requested by #202.