### PR TITLE
Appdata related patches

### DIFF
--- a/data/app.drey.Dialect.desktop.in.in
+++ b/data/app.drey.Dialect.desktop.in.in
@@ -10,6 +10,6 @@ Comment=Translate between languages
 Categories=Network;GTK;
 Icon=@icon@
 # Translators: These are search terms to find this application. Do NOT translate or localize the semicolons. The list MUST also end with a semicolon.
-Keywords=translate;translation;
+Keywords=translate;translation;Google Translate;LibreTranslate;Lingva Translate;Bing Microsoft Translator;Bing Translator;Microsoft Translator;Yandex Translate; 
 # Translators: Do NOT translate or transliterate this text (these are enum types)!
 X-Purism-FormFactor=Workstation;Mobile;

--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -41,6 +41,13 @@
   <keywords>
     <keyword>translate</keyword>
     <keyword>translation</keyword>
+    <keyword>Google Translate</keyword>
+    <keyword>LibreTranslate</keyword>
+    <keyword>Lingva Translate</keyword>
+    <keyword>Bing Microsoft Translator</keyword>
+    <keyword>Bing Translator</keyword>
+    <keyword>Microsoft Translator</keyword>
+    <keyword>Yandex Translate</keyword>
   </keywords>  
 
   <screenshots>

--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -34,9 +34,14 @@
   <launchable type="desktop-id">@app-id@.desktop</launchable>
   <translation type="gettext">dialect</translation>
   
-  <custom>
-    <value key="GnomeSoftware::key-colors">[(108, 236, 156), (0, 0, 0)]</value>
-  </custom>
+  <categories>
+    <category>Network</category>
+    <category>GTK</category>
+  </categories>
+  <keywords>
+    <keyword>translate</keyword>
+    <keyword>translation</keyword>
+  </keywords>  
 
   <screenshots>
     <screenshot type="default">
@@ -187,7 +192,7 @@
     <control>touch</control>
   </recommends>
   <custom>
-    <value key="Purism::form_factor">workstation</value>
     <value key="Purism::form_factor">mobile</value>
+    <value key="GnomeSoftware::key-colors">[(108, 236, 156), (0, 0, 0)]</value>
   </custom>
 </component>

--- a/data/meson.build
+++ b/data/meson.build
@@ -37,10 +37,10 @@ appstream_file = i18n.merge_file(
   install: true,
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
-    args: ['validate-relax', appstream_file.full_path()]
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
+    args: ['validate', appstream_file.full_path()]
   )
 endif
 


### PR DESCRIPTION
### appdata: Use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.

### appdata: Update appdata

- Add categories and keywords tags
- Remove duplicate Purism tag to pass validation check
- Fix duplicate custom tag error

### appdata: Add more keywords

- Add several keywords that may be related the application.