### PR TITLE
Add shortcuts to change font size

### DIFF
--- a/data/resources/shortcuts.blp
+++ b/data/resources/shortcuts.blp
@@ -36,6 +36,16 @@ template $DialectShortcutsWindow : ShortcutsWindow {
         title: C_("shortcuts window", "Show Pronunciation");
         action-name: "app.pronunciation";
       }
+
+      ShortcutsShortcut {
+        title: C_("shortcuts window", "Increase font size");
+        action-name: "win.inc-font";
+      }
+
+      ShortcutsShortcut {
+        title: C_("shortcuts window", "Decrease font size");
+        action-name: "win.dec-font";
+      }
     }
 
     ShortcutsGroup {

--- a/dialect/main.py
+++ b/dialect/main.py
@@ -125,6 +125,8 @@ class Dialect(Adw.Application):
         self.set_accels_for_action('win.forward', ['<Alt>Right'])
         self.set_accels_for_action('win.switch', ['<Primary>S'])
         self.set_accels_for_action('win.clear', ['<Primary>D'])
+        self.set_accels_for_action('win.inc-font', ['<Primary>plus'])
+        self.set_accels_for_action('win.dec-font', ['<Primary>minus'])
         self.set_accels_for_action('win.paste', ['<Primary><Shift>V'])
         self.set_accels_for_action('win.copy', ['<Primary><Shift>C'])
         self.set_accels_for_action('win.listen-dest', ['<Primary>L'])


### PR DESCRIPTION
This is the first step towards making the font size configurable, as requested by #332 and #306.
There are no shortcuts using the mouse wheel as it doesn't seem to be possible to add that as an accelerator.