### PR TITLE
appdata: use --no-net for validation

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -40,7 +40,7 @@ appstream_file = i18n.merge_file(
 appstreamcli = find_program('appstreamcli', required: false)
 if appstreamcli.found()
   test('Validate appstream file', appstreamcli,
-    args: ['validate', appstream_file.full_path()]
+    args: ['validate', '--no-net', appstream_file.full_path()]
   )
 endif
 


### PR DESCRIPTION
This option uses offline validation and limits checking URLs during the build process. It prevents irrelevant requests to the servers.