### PR TITLE
window: only allocate the needed width of title widget

### DIFF
--- a/data/resources/window.blp
+++ b/data/resources/window.blp
@@ -248,6 +248,7 @@ template $DialectWindow : Adw.ApplicationWindow {
             centering-policy: strict;
             title-widget: Stack title_stack {
               transition-type: crossfade;
+              hhomogeneous: false;
 
               StackPage {
                 name: "selector";


### PR DESCRIPTION
The title widget is switched out using a stack, with a Gtk.Stack for hhomogeneous having a default value of true.

Thus, each possible title widget is allocated the same width, and the vertical view is constrained by the width of the language selector even if the "Dialect" string is visible.

With a longer translation of "Auto" and/or a non-default window button layout with at least one on the left or at least two on the right, this results in the window not being able to shrink down to 360px.