### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/build-aux/flatpak/app.drey.Dialect.Devel.json
+++ b/build-aux/flatpak/app.drey.Dialect.Devel.json
@@ -33,6 +33,7 @@
         {
             "name" : "dialect",
             "buildsystem" : "meson",
+            "run-tests": true,
             "config-opts": ["-Dprofile=development"],
             "sources" : [
                 {

--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -29,7 +29,11 @@
   <url type="bugtracker">https://github.com/dialect-app/dialect/issues/</url>
   <url type="translate">https://hosted.weblate.org/engage/dialect/</url>
   <url type="vcs-browser">https://github.com/dialect-app/dialect/</url>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name>The Dialect Authors</developer_name>
+  <developer id="github.com">
+      <name>The Dialect Authors</name>
+  </developer>
   <content_rating type="oars-1.1" />
 
   <launchable type="desktop-id">@app-id@.desktop</launchable>

--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -34,22 +34,6 @@
 
   <launchable type="desktop-id">@app-id@.desktop</launchable>
   <translation type="gettext">dialect</translation>
-  
-  <categories>
-    <category>Network</category>
-    <category>GTK</category>
-  </categories>
-  <keywords>
-    <keyword>translate</keyword>
-    <keyword>translation</keyword>
-    <keyword>Google Translate</keyword>
-    <keyword>LibreTranslate</keyword>
-    <keyword>Lingva Translate</keyword>
-    <keyword>Bing Microsoft Translator</keyword>
-    <keyword>Bing Translator</keyword>
-    <keyword>Microsoft Translator</keyword>
-    <keyword>Yandex Translate</keyword>
-  </keywords>  
 
   <screenshots>
     <screenshot type="default">

--- a/data/meson.build
+++ b/data/meson.build
@@ -40,7 +40,7 @@ appstream_file = i18n.merge_file(
 appstreamcli = find_program('appstreamcli', required: false)
 if appstreamcli.found()
   test('Validate appstream file', appstreamcli,
-    args: ['validate', '--no-net', appstream_file.full_path()]
+    args: ['validate', '--no-net', '--explain', appstream_file.full_path()]
   )
 endif
 


### PR DESCRIPTION
### appdata: Improve appdata for AppStream 1.0

- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Improve appstreamcli arguments
- Activate meson tests on Flatpak manifest

### appdata: Fix my mistake

"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it.
Most of the icon not found errors with the flathub builder can be
traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them
(even though then it might be a better idea to patch the desktop file
itself)."

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories