### PR TITLE
Deepl API provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,12 @@ sudo apt-get install dialect
 - PyGObject `python-gobject`
 - GTK4 `gtk4`
 - libadwaita (>= 1.4.0) `libadwaita`
+- libsoup (>= 3.0) `libsoup`
+- libsecret
 - GStreamer 1.0 `gstreamer`
 - Meson `meson`
 - Ninja `ninja`
 - gTTS `python-gtts`
-- D-Bus `python-dbus`
 - Beautiful Soup `python-beautifulsoup4`
 
 If official packages are not available for any of the python dependencies, you can install them from pip:

--- a/data/resources/provider-preferences.blp
+++ b/data/resources/provider-preferences.blp
@@ -78,6 +78,25 @@ template $ProviderPreferences : Adw.NavigationPage {
           }
         }
       }
+
+      Adw.PreferencesGroup api_usage_group {
+        title: _("Character Usage");
+        visible: false;
+
+        Box {
+          orientation: vertical;
+          spacing: 3;
+
+          LevelBar api_usage {
+
+          }
+
+          Label api_usage_label {
+
+          }
+        }
+
+      }
     }
   }
 }

--- a/data/resources/window.blp
+++ b/data/resources/window.blp
@@ -399,7 +399,7 @@ template $DialectWindow : Adw.ApplicationWindow {
                   Button clear_btn {
                     action-name: "win.clear";
                     tooltip-text: _("Clear");
-                    icon-name: "edit-clear-all-symbolic";
+                    icon-name: "edit-clear-symbolic";
                   }
 
                   Button paste_btn {

--- a/dialect/dialect.in
+++ b/dialect/dialect.in
@@ -4,11 +4,11 @@
 # Copyright 2020 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import os
-import sys
-import signal
-import locale
 import gettext
+import locale
+import os
+import signal
+import sys
 
 pkgdatadir = '@pkgdatadir@'
 localedir = '@localedir@'

--- a/dialect/main.py
+++ b/dialect/main.py
@@ -8,6 +8,7 @@ import logging
 import sys
 
 import gi
+
 try:
     gi.require_version('Gdk', '4.0')
     gi.require_version('Gtk', '4.0')

--- a/dialect/main.py
+++ b/dialect/main.py
@@ -13,6 +13,7 @@ try:
     gi.require_version('Gtk', '4.0')
     gi.require_version('Gst', '1.0')
     gi.require_version('Adw', '1')
+    gi.require_version('Secret', '1')
     gi.require_version('Soup', '3.0')
 
     from gi.repository import Adw, Gio, GLib, Gst, Gtk

--- a/dialect/meson.build
+++ b/dialect/meson.build
@@ -34,6 +34,7 @@ sources = [
   'session.py',
   'settings.py',
   'shortcuts.py',
+  'utils.py',
   'window.py',
 ]
 # Install sources

--- a/dialect/preferences.py
+++ b/dialect/preferences.py
@@ -8,8 +8,8 @@ import os
 from gi.repository import Adw, Gio, Gtk
 
 from dialect.define import RES_PATH
+from dialect.providers import MODULES, TTS, ProviderFeature, ProvidersListModel
 from dialect.settings import Settings
-from dialect.providers import ProviderFeature, ProvidersListModel, MODULES, TTS
 from dialect.widgets import ProviderPreferences
 
 

--- a/dialect/providers/__init__.py
+++ b/dialect/providers/__init__.py
@@ -8,8 +8,13 @@ import pkgutil
 
 from gi.repository import Gio, GObject
 
-from dialect.providers.base import ProviderCapability, ProviderFeature, ProviderError, ProviderErrorCode  # noqa
 from dialect.providers import modules
+from dialect.providers.base import (  # noqa
+    ProviderCapability,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderFeature,
+)
 
 MODULES = {}
 TRANSLATORS = {}

--- a/dialect/providers/base.py
+++ b/dialect/providers/base.py
@@ -132,8 +132,7 @@ class BaseProvider:
     Providers API methods
     """
 
-    @staticmethod
-    def validate_instance(url: str, on_done: Callable[[bool], None], on_fail: Callable[[ProviderError], None]):
+    def validate_instance(self, url: str, on_done: Callable[[bool], None], on_fail: Callable[[ProviderError], None]):
         """
         Validate an instance of the provider.
 

--- a/dialect/providers/base.py
+++ b/dialect/providers/base.py
@@ -32,6 +32,8 @@ class ProviderFeature(Flag):
     """ If the api key is supported but not necessary """
     API_KEY_REQUIRED = auto()
     """ If the api key is required for the provider to work """
+    API_KEY_USAGE = auto()
+    """ If the service reports api usage """
     DETECTION = auto()
     """ If it supports detecting text language (Auto translation) """
     MISTAKES = auto()
@@ -217,6 +219,20 @@ class BaseProvider:
         """
         raise NotImplementedError()
 
+    def api_char_usage(
+        self,
+        on_done: Callable[[int, int], None],
+        on_fail: Callable[[ProviderError], None],
+    ):
+        """
+        Retrieves the API usage status
+
+        Args:
+            on_done: Called after the process successful, with the usage and limit as args
+            on_fail: Called after any error on the speech process
+        """
+        raise NotImplementedError()  
+
     @property
     def lang_aliases(self) -> dict[str, str]:
         """
@@ -301,10 +317,11 @@ class BaseProvider:
 
         If url is localhost, `http` is ignored and HTTP protocol is forced.
 
-        url: Base url, hostname and tld
-        path: Path of the url
-        params: Params to populate a url query
-        http: If HTTP should be used instead of HTTPS
+        Args:
+            url: Base url, hostname and tld
+            path: Path of the url
+            params: Params to populate a url query
+            http: If HTTP should be used instead of HTTPS
         """
 
         if not path.startswith('/'):

--- a/dialect/providers/base.py
+++ b/dialect/providers/base.py
@@ -126,7 +126,7 @@ class BaseProvider:
         """ Here we save the translation history """
 
         # GSettings
-        self.settings = ProviderSettings(self.name)
+        self.settings = ProviderSettings(self.name, self.defaults)
 
     """
     Providers API methods

--- a/dialect/providers/base.py
+++ b/dialect/providers/base.py
@@ -8,10 +8,9 @@ from dataclasses import dataclass
 from enum import Enum, Flag, auto
 from typing import Callable, Optional
 
-from gi.repository import Gio
-
-from dialect.define import APP_ID, LANG_ALIASES
+from dialect.define import LANG_ALIASES
 from dialect.languages import get_lang_name
+from dialect.providers.settings import ProviderSettings
 
 
 class ProviderCapability(Flag):
@@ -127,7 +126,7 @@ class BaseProvider:
         """ Here we save the translation history """
 
         # GSettings
-        self.settings = Gio.Settings(f'{APP_ID}.translator', f'/app/drey/Dialect/translators/{self.name}/')
+        self.settings = ProviderSettings(self.name)
 
     """
     Providers API methods
@@ -295,11 +294,11 @@ class BaseProvider:
     @property
     def instance_url(self):
         """Instance url saved on settings."""
-        return self.settings.get_string('instance-url') or self.defaults['instance_url']
+        return self.settings.instance_url or self.defaults['instance_url']
 
     @instance_url.setter
     def instance_url(self, url):
-        self.settings.set_string('instance-url', url)
+        self.settings.instance_url = url
 
     def reset_instance_url(self):
         """Resets saved instance url."""
@@ -308,11 +307,11 @@ class BaseProvider:
     @property
     def api_key(self):
         """API key saved on settings."""
-        return self.settings.get_string('api-key') or self.defaults['api_key']
+        return self.settings.api_key or self.defaults['api_key']
 
     @api_key.setter
     def api_key(self, api_key):
-        self.settings.set_string('api-key', api_key)
+        self.settings.api_key = api_key
 
     def reset_api_key(self):
         """Resets saved API key."""
@@ -321,28 +320,28 @@ class BaseProvider:
     @property
     def recent_src_langs(self):
         """Saved recent source langs of the user."""
-        return self.settings.get_strv('src-langs') or self.defaults['src_langs']
+        return self.settings.src_langs or self.defaults['src_langs']
 
     @recent_src_langs.setter
     def recent_src_langs(self, src_langs):
-        self.settings.set_strv('src-langs', src_langs)
+        self.settings.src_langs = src_langs
 
     def reset_src_langs(self):
         """Reset saved recent user source langs"""
-        self.src_langs = []
+        self.recent_src_langs = []
 
     @property
     def recent_dest_langs(self):
         """Saved recent destination langs of the user."""
-        return self.settings.get_strv('dest-langs') or self.defaults['dest_langs']
+        return self.settings.dest_langs or self.defaults['dest_langs']
 
     @recent_dest_langs.setter
     def recent_dest_langs(self, dest_langs):
-        self.settings.set_strv('dest-langs', dest_langs)
+        self.settings.dest_langs = dest_langs
 
     def reset_dest_langs(self):
         """Reset saved recent user destination langs"""
-        self.dest_langs = []
+        self.recent_dest_langs = []
 
     """
     General provider helpers

--- a/dialect/providers/modules/bing.py
+++ b/dialect/providers/modules/bing.py
@@ -101,7 +101,7 @@ class Provider(SoupProvider):
         message = self.create_message('GET', self.html_url, headers=self._headers)
 
         # Do async request
-        self.send_and_read_and_process_response(message, on_response, on_fail, json=False)
+        self.send_and_read_and_process_response(message, on_response, on_fail, False, False)
 
     def translate(self, text, src, dest, on_done, on_fail):
         def on_response(data):
@@ -145,8 +145,7 @@ class Provider(SoupProvider):
         # Do async request
         self.send_and_read_and_process_response(message, on_response, on_fail)
 
-    @staticmethod
-    def check_known_errors(data):
+    def check_known_errors(self, _status, data):
         if not data:
             return ProviderError(ProviderErrorCode.EMPTY, 'Response is empty!')
 

--- a/dialect/providers/modules/deepl.py
+++ b/dialect/providers/modules/deepl.py
@@ -1,0 +1,183 @@
+# Copyright 2024 Mufeed Ali
+# Copyright 2024 Rafael Mardojai CM
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+
+from dialect.providers.base import (
+    ProviderCapability,
+    ProviderFeature,
+    ProviderErrorCode,
+    ProviderError,
+    Translation,
+)
+from dialect.providers.soup import SoupProvider
+
+API_V = "v2"
+
+
+class Provider(SoupProvider):
+    name = 'deepl'
+    prettyname = 'DeepL'
+
+    capabilities = ProviderCapability.TRANSLATION
+    features = (
+        ProviderFeature.DETECTION
+        | ProviderFeature.API_KEY
+        | ProviderFeature.API_KEY_REQUIRED
+        | ProviderFeature.API_KEY_USAGE
+    )
+
+    defaults = {
+        'instance_url': 'api-free.deepl.com',
+        'api_key': '',
+        'src_langs': ['en', 'fr', 'es', 'de'],
+        'dest_langs': ['fr', 'es', 'de', 'en-US'],
+    }
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.chars_limit = 5000
+
+    @property
+    def source_lang_url(self):
+        return self.format_url(self.instance_url, f'/{API_V}/languages', {'type': 'source'})
+    
+    @property
+    def target_lang_url(self):
+        return self.format_url(self.instance_url, f'/{API_V}/languages', {'type': 'target'})
+
+    @property
+    def translate_url(self):
+        return self.format_url(self.instance_url, f'/{API_V}/translate')
+
+    @property
+    def usage_url(self):
+        return self.format_url(self.instance_url, f"/{API_V}/usage")
+
+    @property
+    def headers(self):
+        return {'Authorization': f'DeepL-Auth-Key {self.api_key}'}
+
+    def init_trans(self, on_done, on_fail):
+        def check_finished():
+            self._init_count -= 1
+
+            if self._init_count == 0:
+                if self._init_error:
+                    on_fail(self._init_error)
+                else:
+                    on_done()
+
+        def on_failed(error):
+            self._init_error = error
+            check_finished()
+
+        def on_languages_response(data, type_):
+            try:
+                trans_src = type_ == 'src'
+                trans_dest = type_ == 'dest'
+
+                for lang in data:
+                    self.add_lang(lang['language'], lang['name'], trans_src=trans_src, trans_dest=trans_dest)
+
+                check_finished()
+
+            except Exception as exc:
+                print(type_)
+                logging.warning(exc)
+                on_failed(ProviderError(ProviderErrorCode.UNEXPECTED, str(exc)))
+
+        # Keep state of multiple request
+        self._init_count = 2
+        self._init_error = None
+
+        # Request messages
+        src_langs_message = self.create_message('GET', self.source_lang_url, headers=self.headers)
+        dest_langs_message = self.create_message('GET', self.target_lang_url, headers=self.headers)
+
+        # Do async requests
+        self.send_and_read_and_process_response(src_langs_message, lambda d: on_languages_response(d, 'src'), on_failed)
+        self.send_and_read_and_process_response(dest_langs_message, lambda d: on_languages_response(d, 'dest'), on_failed)
+
+    def validate_api_key(self, key, on_done, on_fail):
+        def on_response(_data):
+            valid = languages_message.get_status() == 200
+            on_done(valid)
+
+        # Headers
+        headers = {'Authorization': f'DeepL-Auth-Key {key}'}
+        # Request messages
+        languages_message = self.create_message('GET', self.source_lang_url, headers=headers)
+        # Do async requests
+        self.send_and_read_and_process_response(languages_message, on_response, on_fail)
+
+    def translate(self, text, src, dest, on_done, on_fail):
+        def on_response(data):
+            try:
+                translations = data.get('translations')
+                detected = translations[0].get('detected_source_language')
+                translation = Translation(translations[0]['text'], (text, src, dest), detected)
+                on_done(translation)
+
+            except Exception as exc:
+                logging.warning(exc)
+                on_fail(ProviderError(ProviderErrorCode.TRANSLATION_FAILED, str(exc)))
+
+        # Request body
+        data = {
+            'text': [text],
+            'target_lang': dest,
+        }
+        if src != 'auto':
+            data['source_lang'] = src
+
+        # Request message
+        message = self.create_message('POST', self.translate_url, data, self.headers)
+        # Do async request
+        self.send_and_read_and_process_response(message, on_response, on_fail)
+
+    def api_char_usage(self, on_done, on_fail):
+        def on_response(data):
+            try:
+                usage = data.get('character_count')
+                limit = data.get('character_limit')
+                on_done(usage, limit)
+
+            except Exception as exc:
+                logging.warning(exc)
+                on_fail(ProviderError(ProviderErrorCode.UNEXPECTED, str(exc)))
+
+        # Request message
+        message = self.create_message('GET', self.usage_url, headers=self.headers)
+        # Do async request
+        self.send_and_read_and_process_response(message, on_response, on_fail)
+
+    def cmp_langs(self, a, b):
+        # Early return if both langs are just the same
+        if a == b:
+            return True
+
+        # Split lang code to separate it from possible country/script code
+        a_codes = a.split('-')
+        b_codes = b.split('-')
+
+        if a_codes[0] == b_codes[0]:  # Check base codes
+            return True
+
+        return False
+
+    def check_known_errors(self, status, data):
+        message = data.get('message', '') if isinstance(data, dict) else ''
+
+        match status:
+            case 403:
+                if not self.api_key:
+                    return ProviderError(ProviderErrorCode.API_KEY_REQUIRED, message)
+                return ProviderError(ProviderErrorCode.API_KEY_INVALID, message)
+            case 456:
+                return ProviderError(ProviderErrorCode.SERVICE_LIMIT_REACHED, message)
+
+        if status != 200:
+            return ProviderError(ProviderErrorCode.UNEXPECTED, message)

--- a/dialect/providers/modules/google.py
+++ b/dialect/providers/modules/google.py
@@ -370,7 +370,7 @@ class Provider(LocalProvider, SoupProvider):
 
     def init_tts(self, on_done, on_fail):
         for code in lang.tts_langs().keys():
-            self.add_lang(code, trans=False, tts=True)
+            self.add_lang(code, trans_src=False, trans_dest=False, tts=True)
 
         on_done()
 

--- a/dialect/providers/modules/google.py
+++ b/dialect/providers/modules/google.py
@@ -475,7 +475,7 @@ class Provider(LocalProvider, SoupProvider):
 
                 if src == 'auto':
                     try:
-                        if parsed[0][2] in self.languages:
+                        if parsed[0][2] in self.src_languages:
                             src = parsed[0][2]
                     except (IndexError, TypeError):
                         pass

--- a/dialect/providers/modules/google.py
+++ b/dialect/providers/modules/google.py
@@ -532,7 +532,7 @@ class Provider(LocalProvider, SoupProvider):
         message = self.create_message('POST', self.translate_url, data, self._headers, True)
 
         # Do async request
-        self.send_and_read_and_process_response(message, on_response, on_fail, json=False)
+        self.send_and_read_and_process_response(message, on_response, on_fail, False, False)
 
     def _strip_html_tags(self, text):
         """Strip html tags"""

--- a/dialect/providers/modules/libretrans.py
+++ b/dialect/providers/modules/libretrans.py
@@ -175,7 +175,7 @@ class Provider(SoupProvider):
             'target': dest,
             's': suggestion,
         }
-        if self.api_key and self.api_key_supported:
+        if self.api_key and ProviderFeature.API_KEY in self.features:
             data['api_key'] = self.api_key
 
         # Request message

--- a/dialect/providers/modules/libretrans.py
+++ b/dialect/providers/modules/libretrans.py
@@ -33,8 +33,7 @@ class Provider(SoupProvider):
 
         self.chars_limit = 0
 
-    @staticmethod
-    def validate_instance(url, on_done, on_fail):
+    def validate_instance(self, url, on_done, on_fail):
         def on_response(data):
             valid = False
 
@@ -46,9 +45,9 @@ class Provider(SoupProvider):
             on_done(valid)
 
         # Message request to LT API spec endpoint
-        message = Provider.create_message('GET', Provider.format_url(url, '/spec'))
+        message = self.create_message('GET', self.format_url(url, '/spec'))
         # Do async request
-        Provider.send_and_read_and_process_response(message, on_response, on_fail, False)
+        self.send_and_read_and_process_response(message, on_response, on_fail, False)
 
     @property
     def frontend_settings_url(self):

--- a/dialect/providers/modules/libretrans.py
+++ b/dialect/providers/modules/libretrans.py
@@ -184,8 +184,7 @@ class Provider(SoupProvider):
         # Do async request
         self.send_and_read_and_process_response(message, on_response, on_fail)
 
-    @staticmethod
-    def check_known_errors(data):
+    def check_known_errors(self, _status, data):
         if not data:
             return ProviderError(ProviderErrorCode.EMPTY, 'Response is empty!')
         if 'error' in data:

--- a/dialect/providers/modules/lingva.py
+++ b/dialect/providers/modules/lingva.py
@@ -4,7 +4,7 @@
 
 import logging
 from tempfile import NamedTemporaryFile
-import urllib
+from urllib.parse import quote
 
 from dialect.providers.base import (
     ProviderCapability,
@@ -109,7 +109,7 @@ class Provider(SoupProvider):
                 on_fail(ProviderError(ProviderErrorCode.TRANSLATION_FAILED, error))
 
         # Format url query data
-        text = urllib.parse.quote(text, safe='')
+        text = quote(text, safe='')
         url = self.translate_url.format(text=text, src=src, dest=dest)
 
         # Request message

--- a/dialect/providers/modules/lingva.py
+++ b/dialect/providers/modules/lingva.py
@@ -140,8 +140,7 @@ class Provider(SoupProvider):
         # Do async request
         self.send_and_read_and_process_response(message, on_response, on_fail)
 
-    @staticmethod
-    def check_known_errors(data):
+    def check_known_errors(self, _status, data):
         """Raises a proper Exception if an error is found in the data."""
         if not data:
             return ProviderError(ProviderErrorCode.EMPTY, 'Response is empty!')

--- a/dialect/providers/modules/lingva.py
+++ b/dialect/providers/modules/lingva.py
@@ -37,8 +37,7 @@ class Provider(SoupProvider):
 
         self.chars_limit = 5000
 
-    @staticmethod
-    def validate_instance(url, on_done, on_fail):
+    def validate_instance(self, url, on_done, on_fail):
         def on_response(data):
             valid = False
             try:
@@ -49,9 +48,9 @@ class Provider(SoupProvider):
             on_done(valid)
 
         # Lingva translation endpoint
-        message = Provider.create_message('GET', Provider.format_url(url, '/api/v1/en/es/hello'))
+        message = self.create_message('GET', self.format_url(url, '/api/v1/en/es/hello'))
         # Do async request
-        Provider.send_and_read_and_process_response(message, on_response, on_fail, False)
+        self.send_and_read_and_process_response(message, on_response, on_fail, False)
 
     @property
     def lang_url(self):

--- a/dialect/providers/modules/yandex.py
+++ b/dialect/providers/modules/yandex.py
@@ -39,7 +39,7 @@ class Provider(SoupProvider):
         self._uuid = str(uuid4()).replace('-', '')
 
     def init_trans(self, on_done, on_fail):
-        self.languages = [
+        languages = [
             'af',
             'sq',
             'am',
@@ -141,6 +141,8 @@ class Provider(SoupProvider):
             'yi',
             'zu',
         ]
+        for code in languages:
+            self.add_lang(code)
 
         on_done()
 

--- a/dialect/providers/settings.py
+++ b/dialect/providers/settings.py
@@ -4,7 +4,7 @@
 
 import logging
 
-from gi.repository import Gio, GLib, GObject, Secret
+from gi.repository import Gio, GLib, Secret
 
 from dialect.define import APP_ID
 

--- a/dialect/providers/settings.py
+++ b/dialect/providers/settings.py
@@ -23,7 +23,7 @@ class ProviderSettings(Gio.Settings):
     Helper class for providers settings
     """
 
-    def __init__(self, name: str, defaults: dict[str, list[str]]):
+    def __init__(self, name: str, defaults: dict[str, str | list[str]]):
         super().__init__(f'{APP_ID}.translator', f'/app/drey/Dialect/translators/{name}/')
 
         self.name = name

--- a/dialect/providers/settings.py
+++ b/dialect/providers/settings.py
@@ -23,11 +23,12 @@ class ProviderSettings(Gio.Settings):
     Helper class for providers settings
     """
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, defaults: dict[str, list[str]]):
         super().__init__(f'{APP_ID}.translator', f'/app/drey/Dialect/translators/{name}/')
 
         self.name = name
         self._secret_attr = {'provider': name}
+        self.defaults = defaults  # set of per-provider defaults
 
     @property
     def instance_url(self) -> str:

--- a/dialect/providers/settings.py
+++ b/dialect/providers/settings.py
@@ -8,7 +8,6 @@ from gi.repository import Gio, GLib, Secret
 
 from dialect.define import APP_ID
 
-
 SECRETS_SCHEMA = Secret.Schema.new(
     APP_ID,
     Secret.SchemaFlags.NONE,

--- a/dialect/providers/settings.py
+++ b/dialect/providers/settings.py
@@ -1,0 +1,95 @@
+# Copyright 2024 Mufeed Ali
+# Copyright 2024 Rafael Mardojai CM
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import logging
+
+from gi.repository import Gio, GLib, GObject, Secret
+
+from dialect.define import APP_ID
+
+
+SECRETS_SCHEMA = Secret.Schema.new(
+    APP_ID,
+    Secret.SchemaFlags.NONE,
+    {
+        'provider': Secret.SchemaAttributeType.STRING,
+    },
+)
+
+
+class ProviderSettings(Gio.Settings):
+    """
+    Helper class for providers settings
+    """
+
+    def __init__(self, name: str):
+        super().__init__(f'{APP_ID}.translator', f'/app/drey/Dialect/translators/{name}/')
+
+        self.name = name
+        self._secret_attr = {'provider': name}
+
+    @property
+    def instance_url(self) -> str:
+        """Instance url."""
+        return self.get_string('instance-url')
+
+    @instance_url.setter
+    def instance_url(self, url: str):
+        self.set_string('instance-url', url)
+
+    @property
+    def api_key(self) -> str | None:
+        """API key."""
+
+        # Check if we have an old API KEY in GSettings for migration
+        if gsettings := self.get_string('api-key'):
+            self.api_key = gsettings  # Save to secret
+            self.set_string('api-key', '')  # Clear GSetting
+            return gsettings
+
+        try:
+            return Secret.password_lookup_sync(SECRETS_SCHEMA, self._secret_attr, None)
+        except GLib.GError as exc:
+            logging.warning(exc)
+
+        return None
+
+    @api_key.setter
+    def api_key(self, api_key: str):
+        try:
+            if api_key:
+                Secret.password_store_sync(
+                    SECRETS_SCHEMA,
+                    self._secret_attr,
+                    Secret.COLLECTION_DEFAULT,
+                    f'Dialect provider API KEY for {self.name}',
+                    api_key,
+                    None,
+                )
+            else:  # Remove secret
+                Secret.password_clear_sync(SECRETS_SCHEMA, self._secret_attr, None)
+
+            # Fake change in api-key setting
+            self.emit('changed::api-key', 'api-key')
+
+        except GLib.GError as exc:
+            logging.warning(exc)
+
+    @property
+    def src_langs(self) -> list[str]:
+        """Recent source languages."""
+        return self.get_strv('src-langs') or self.defaults['src_langs']
+
+    @src_langs.setter
+    def src_langs(self, src_langs: list[str]):
+        self.set_strv('src-langs', src_langs)
+
+    @property
+    def dest_langs(self) -> list[str]:
+        """Recent destination languages."""
+        return self.get_strv('dest-langs') or self.defaults['dest_langs']
+
+    @dest_langs.setter
+    def dest_langs(self, dest_langs: list[str]):
+        self.set_strv('dest-langs', dest_langs)

--- a/dialect/providers/soup.py
+++ b/dialect/providers/soup.py
@@ -6,7 +6,7 @@ import json
 import logging
 from typing import Callable
 
-from gi.repository import GLib, Gio, Soup
+from gi.repository import Gio, GLib, Soup
 
 from dialect.providers.base import BaseProvider, ProviderError, ProviderErrorCode
 from dialect.session import Session

--- a/dialect/providers/soup.py
+++ b/dialect/providers/soup.py
@@ -18,8 +18,7 @@ class SoupProvider(BaseProvider):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    @staticmethod
-    def encode_data(data) -> GLib.Bytes | None:
+    def encode_data(self, data) -> GLib.Bytes | None:
         """
         Convert Python data to JSON and bytes.
 
@@ -34,8 +33,7 @@ class SoupProvider(BaseProvider):
             logging.warning(exc)
         return data_glib_bytes
 
-    @staticmethod
-    def create_message(method: str, url: str, data={}, headers: dict = {}, form: bool = False) -> Soup.Message:
+    def create_message(self, method: str, url: str, data={}, headers: dict = {}, form: bool = False) -> Soup.Message:
         """
         Create a libsoup's message.
 
@@ -56,7 +54,7 @@ class SoupProvider(BaseProvider):
         else:
             message = Soup.Message.new(method, url)
         if data and not form:
-            data = SoupProvider.encode_data(data)
+            data = self.encode_data(data)
             message.set_request_body_from_bytes('application/json', data)
         if headers:
             for name, value in headers.items():
@@ -65,8 +63,7 @@ class SoupProvider(BaseProvider):
             message.get_request_headers().append('User-Agent', 'Dialect App')
         return message
 
-    @staticmethod
-    def send_and_read(message: Soup.Message, callback: Callable[[Session, Gio.AsyncResult], None]):
+    def send_and_read(self, message: Soup.Message, callback: Callable[[Session, Gio.AsyncResult], None]):
         """
         Helper method for libsoup's send_and_read_async.
 
@@ -78,8 +75,7 @@ class SoupProvider(BaseProvider):
         """
         Session.get().send_and_read_async(message, 0, None, callback)
 
-    @staticmethod
-    def read_data(data: bytes) -> dict:
+    def read_data(self, data: bytes) -> dict:
         """
         Get JSON data from bytes.
 
@@ -88,8 +84,7 @@ class SoupProvider(BaseProvider):
         """
         return json.loads(data) if data else {}
 
-    @staticmethod
-    def read_response(session: Session, result: Gio.AsyncResult) -> dict:
+    def read_response(self, session: Session, result: Gio.AsyncResult) -> dict:
         """
         Get JSON data from session result.
 
@@ -100,10 +95,9 @@ class SoupProvider(BaseProvider):
             result: Result of send_and_read_async callback
         """
         response = session.get_response(session, result)
-        return SoupProvider.read_data(response)
+        return self.read_data(response)
 
-    @staticmethod
-    def check_known_errors(data: dict) -> None | ProviderError:
+    def check_known_errors(self, status: Soup.Status, data: dict) -> None | ProviderError:
         """
         Checks data for possible response errors and return a found error if any.
 
@@ -114,10 +108,11 @@ class SoupProvider(BaseProvider):
         """
         return None
 
-    @staticmethod
     def process_response(
+        self,
         session: Session,
         result: Gio.AsyncResult,
+        message: Soup.Message,
         on_continue: Callable[[dict | bytes], None],
         on_fail: Callable[[ProviderError], None],
         check_common: bool = True,
@@ -135,6 +130,7 @@ class SoupProvider(BaseProvider):
         Args:
             session: Session where the request wa sent
             result: Result of send_and_read_async callback
+            message: The message that was sent
             on_continue: Called after data was got successfully
             on_fail: Called after any error on request or in check_known_errors
             check_common: If response data should be checked for errors using check_known_errors
@@ -143,15 +139,15 @@ class SoupProvider(BaseProvider):
 
         try:
             if json:
-                data = SoupProvider.read_response(session, result)
-
-                if check_common:
-                    error = SoupProvider.check_known_errors(data)
-                    if error:
-                        on_fail(error)
-                        return
+                data = self.read_response(session, result)
             else:
                 data = Session.get_response(session, result)
+
+            if check_common:
+                error = self.check_known_errors(message.get_status(), data)
+                if error:
+                    on_fail(error)
+                    return
 
             on_continue(data)
 
@@ -159,8 +155,8 @@ class SoupProvider(BaseProvider):
             logging.warning(exc)
             on_fail(ProviderError(ProviderErrorCode.NETWORK, str(exc)))
 
-    @staticmethod
     def send_and_read_and_process_response(
+        self,
         message: Soup.Message,
         on_continue: Callable[[dict | bytes], None],
         on_fail: Callable[[ProviderError], None],
@@ -180,6 +176,6 @@ class SoupProvider(BaseProvider):
         """
 
         def on_response(session: Session, result: Gio.AsyncResult):
-            SoupProvider.process_response(session, result, on_continue, on_fail, check_common, json)
+            self.process_response(session, result, message, on_continue, on_fail, check_common, json)
 
-        SoupProvider.send_and_read(message, on_response)
+        self.send_and_read(message, on_response)

--- a/dialect/search_provider/search_provider.in
+++ b/dialect/search_provider/search_provider.in
@@ -6,21 +6,18 @@
 # Copyright 2023 Markus Göllnitz
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import sys
-import logging
-import locale
 import gettext
+import locale
+import sys
 
 import gi
 
 gi.require_version('Soup', '3.0')
-from gi.repository import GLib, Gio
+from gi.repository import Gio, GLib
 
-from dialect.session import Session
-from dialect.settings import Settings
-from dialect.languages import get_lang_name
 from dialect.providers import TRANSLATORS
 from dialect.providers.base import ProviderErrorCode
+from dialect.settings import Settings
 
 CLIPBOARD_PREFIX = 'copy-to-clipboard'
 ERROR_PREFIX = 'translation-error'

--- a/dialect/settings.py
+++ b/dialect/settings.py
@@ -7,9 +7,9 @@ from gi.repository import Gio, GLib, GObject
 
 from dialect.define import APP_ID
 from dialect.providers import (
+    TTS,
     check_translator_availability,
     get_fallback_translator_name,
-    TTS,
 )
 
 

--- a/dialect/settings.py
+++ b/dialect/settings.py
@@ -100,7 +100,7 @@ class Settings(Gio.Settings):
         return self.get_boolean('custom-default-font-size')
 
     @custom_default_font_size.setter
-    def default_font_size(self, enabled):
+    def custom_default_font_size(self, enabled):
         self.set_boolean('custom-default-font-size', enabled)
 
     @property

--- a/dialect/utils.py
+++ b/dialect/utils.py
@@ -11,8 +11,8 @@ def find_item_match(list1: list[str], list2: list[str]) -> str | None:
         list1: List to iterate
         list2: List to check against
     """
-    list2 = set(list2)
-    return next((i for i in list1 if i in list2), None)
+    set_to_check = set(list2)
+    return next((i for i in list1 if i in set_to_check), None)
 
 
 def first_exclude(list_: list[str], exclude: str) -> str | None:

--- a/dialect/utils.py
+++ b/dialect/utils.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Mufeed Ali
+# Copyright 2024 Rafael Mardojai CM
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+def find_item_match(list1: list[str], list2: list[str]) -> str | None:
+    """
+    Get the first occurrence in two lists.
+
+    Args:
+        list1: List to iterate
+        list2: List to check against
+    """
+    list2 = set(list2)
+    return next((i for i in list1 if i in list2), None)
+
+
+def first_exclude(list_: list[str], exclude: str) -> str | None:
+    """
+    Get the first item that is not excluded.
+
+    Args:
+        list_: List of items
+        exclude: Item to ignore
+    """
+    return next((x for x in list_ if x != exclude), None)

--- a/dialect/widgets/provider_preferences.py
+++ b/dialect/widgets/provider_preferences.py
@@ -30,6 +30,9 @@ class ProviderPreferences(Adw.NavigationPage):
     api_key_stack = Gtk.Template.Child()
     api_key_reset = Gtk.Template.Child()
     api_key_spinner = Gtk.Template.Child()
+    api_usage_group = Gtk.Template.Child()
+    api_usage = Gtk.Template.Child()
+    api_usage_label = Gtk.Template.Child()
 
     def __init__(self, scope, dialog, window, **kwargs):
         super().__init__(**kwargs)
@@ -55,8 +58,23 @@ class ProviderPreferences(Adw.NavigationPage):
         self.window.connect('notify::translator-loading', self._on_translator_loading)            
 
     def _check_settings(self):
+        def on_usage(usage, limit):
+            level = usage / limit
+            label = _('{usage:n} of {limit:n} characters').format(usage=usage, limit=limit)
+
+            self.api_usage.props.value = level
+            self.api_usage_label.props.label = label
+            self.api_usage_group.props.visible = True
+
+        def on_usage_fail(_error):
+            pass
+
         self.instance_entry.props.visible = ProviderFeature.INSTANCES in self.provider.features
         self.api_key_entry.props.visible = ProviderFeature.API_KEY in self.provider.features
+
+        self.api_usage_group.props.visible = False
+        if ProviderFeature.API_KEY_USAGE in self.provider.features:
+            self.provider.api_char_usage(on_usage, on_usage_fail)
 
     @Gtk.Template.Callback()
     def _on_instance_apply(self, _row):

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -10,7 +10,13 @@ from gi.repository import Adw, Gdk, Gio, GLib, GObject, Gst, Gtk
 
 from dialect.define import APP_ID, PROFILE, RES_PATH, TRANS_NUMBER
 from dialect.languages import LanguagesListModel
-from dialect.providers import TRANSLATORS, TTS, ProviderFeature, ProviderError, ProviderErrorCode
+from dialect.providers import (
+    TRANSLATORS,
+    TTS,
+    ProviderError,
+    ProviderErrorCode,
+    ProviderFeature,
+)
 from dialect.providers.base import BaseProvider, Translation
 from dialect.settings import Settings
 from dialect.shortcuts import DialectShortcutsWindow


### PR DESCRIPTION
A correct initial implementation needed dome tweaks on other parts of Dialect's code.

There are some open questions:

- ~Do we want to support pro users? DeepL has separate API domains for pro and free users (`api-free.deepl.com` and `api.deepl.com`). We could support this with our current "instances" feature, but that will require users manually setting the pro domain.~

  ~A more complex solution could be made introducing some kind of limited "provider config fields" API so providers can define some configuration fields in the form of entries, dropdows, switches, etc, this also is sort of required if we want to implement an official Microsoft provider (see  #314).~

  No plan to support `api.deepl.com` for now.

- ~Do we know the char limit? The docs mention an `128 KiB` limit, can we convert that to an approximate char limit?~
  Set to 5000 characters. 

TODO:

- [x] We need to extend the providers API to allow different src/dest lang lists. DeepL has two separated lists with some divergences.
- [x] Extend providers API to allow providers report API usage and limits. Then support the new API from the preferences window.
