### PR TITLE
Add Debian instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@ Dialect is available for Fedora 33 and later:
 ```bash
 sudo dnf install dialect
 ```
+### Debian
 
+Dialect is available in Debian 12:
+```bash
+sudo apt-get install dialect
+```
 ## Building
 
 ### Requirements


### PR DESCRIPTION
There are instructions for Flathub, Arch, and Fedora. This adds instructions for Debian.

I didn't check any other Debian-based distros, but I did confirm that Debian 12 (current stable) has Dialect available for installation.