### PR TITLE
Update Developer ID

### DIFF
--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -31,7 +31,7 @@
   <url type="vcs-browser">https://github.com/dialect-app/dialect/</url>
   <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name>The Dialect Authors</developer_name>
-  <developer id="github.com">
+  <developer id="org.dialectapp">
       <name>The Dialect Authors</name>
   </developer>
   <content_rating type="oars-1.1" />


### PR DESCRIPTION
Appstream decided to use reverse DNS for developer IDds.

> The element should have a id property, containing a unique ID to identify the component developer / development team. It is recommended to use a reverse-DNS name, like org.gnome or io.github.ximion, or a Fediverse handle (like @user@example.org) as ID to achieve a higher chance of uniqueness.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer