### PR TITLE
Add appstream brand colors

### DIFF
--- a/data/app.drey.Dialect.metainfo.xml.in.in
+++ b/data/app.drey.Dialect.metainfo.xml.in.in
@@ -206,4 +206,8 @@
     <value key="Purism::form_factor">mobile</value>
     <value key="GnomeSoftware::key-colors">[(108, 236, 156), (0, 0, 0)]</value>
   </custom>
+  <branding>
+    <color type="primary" scheme_preference="light">#a1f6b4</color>
+    <color type="primary" scheme_preference="dark">#157b4c</color>
+  </branding>
 </component>


### PR DESCRIPTION
See this blog post for context: https://docs.flathub.org/blog/introducing-app-brand-colors

![image](https://github.com/dialect-app/dialect/assets/1908896/c8ce9543-d806-4ad9-ba80-caa24491003c)
