### PR TITLE
Experimental async

### DIFF
--- a/dialect/asyncio.py
+++ b/dialect/asyncio.py
@@ -1,0 +1,32 @@
+import asyncio
+import contextlib
+from typing import Coroutine
+
+from gi.events import GLibEventLoopPolicy
+from gi.repository import GLib
+
+
+@contextlib.contextmanager
+def glib_event_loop_policy():
+    original = asyncio.get_event_loop_policy()
+    policy = GLibEventLoopPolicy()
+    asyncio.set_event_loop_policy(policy)
+    try:
+        yield policy
+    finally:
+        asyncio.set_event_loop_policy(original)
+
+
+_background_tasks: set[asyncio.Task] = set()
+
+
+def create_background_task(coro: Coroutine) -> asyncio.Task:
+    """Create and track a task.
+    Normally tasks are weak-referenced by asyncio.
+    We keep track of them, so they can be completed
+    before GC kicks in.
+    """
+    task = asyncio.create_task(coro)
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)
+    return task

--- a/dialect/asyncio.py
+++ b/dialect/asyncio.py
@@ -1,9 +1,9 @@
 import asyncio
 import contextlib
-from typing import Coroutine
+import functools
+from typing import Callable, Coroutine
 
 from gi.events import GLibEventLoopPolicy
-from gi.repository import GLib
 
 
 @contextlib.contextmanager
@@ -21,12 +21,30 @@ _background_tasks: set[asyncio.Task] = set()
 
 
 def create_background_task(coro: Coroutine) -> asyncio.Task:
-    """Create and track a task.
+    """
+    Create and track a task.
+
     Normally tasks are weak-referenced by asyncio.
-    We keep track of them, so they can be completed
-    before GC kicks in.
+    We keep track of them, so they can be completed before GC kicks in.
     """
     task = asyncio.create_task(coro)
     _background_tasks.add(task)
     task.add_done_callback(_background_tasks.discard)
     return task
+
+
+def background_task(f: Callable[..., Coroutine]):
+    """
+    Wraps an async function to be run using ``create_background_task``.
+
+    Useful to use async functions like signal handlers or GTK template callbacks.
+
+    Note: The return value will be lost, so this is not suitable when you need to
+    return something from the coroutine, what might be needed in some signal handlers.
+    """
+
+    @functools.wraps(f)
+    def decor(*args, **kwargs):
+        create_background_task(f(*args, **kwargs))
+
+    return decor

--- a/dialect/main.py
+++ b/dialect/main.py
@@ -21,6 +21,7 @@ try:
 except ImportError or ValueError:
     logging.error("Error: GObject dependencies not met.")
 
+from dialect.asyncio import glib_event_loop_policy
 from dialect.define import APP_ID, RES_PATH, VERSION
 from dialect.preferences import DialectPreferencesDialog
 from dialect.settings import Settings
@@ -198,4 +199,9 @@ class Dialect(Adw.Application):
 def main():
     # Run the Application
     app = Dialect()
-    return app.run(sys.argv)
+    exit_code = 0
+
+    with glib_event_loop_policy():
+        exit_code = app.run(sys.argv)
+
+    return exit_code

--- a/dialect/main.py
+++ b/dialect/main.py
@@ -169,10 +169,7 @@ class Dialect(Adw.Application):
 
         # Update UI
         if self.window:
-            if self.window.trans_src_pron is not None:
-                self.window.src_pron_revealer.props.reveal_child = value  # type: ignore
-            if self.window.trans_dest_pron is not None:
-                self.window.dest_pron_revealer.props.reveal_child = value  # type: ignore
+            self.window._check_pronunciation()
 
     def _on_preferences(self, _action, _param):
         """Show preferences window"""

--- a/dialect/meson.build
+++ b/dialect/meson.build
@@ -59,6 +59,7 @@ subdir('search_provider')
 # Python sources
 sources = [
   '__init__.py',
+  'asyncio.py',
   'languages.py',
   'main.py',
   'preferences.py',

--- a/dialect/providers/__init__.py
+++ b/dialect/providers/__init__.py
@@ -13,6 +13,10 @@ from dialect.providers.base import (  # noqa
     BaseProvider,
     ProviderCapability,
     ProviderFeature,
+    Translation,
+    TranslationMistake,
+    TranslationPronunciation,
+    TranslationRequest,
 )
 from dialect.providers.errors import (  # noqa
     APIKeyInvalid,

--- a/dialect/providers/__init__.py
+++ b/dialect/providers/__init__.py
@@ -12,9 +12,18 @@ from dialect.providers import modules
 from dialect.providers.base import (  # noqa
     BaseProvider,
     ProviderCapability,
-    ProviderError,
-    ProviderErrorCode,
     ProviderFeature,
+)
+from dialect.providers.errors import (  # noqa
+    APIKeyInvalid,
+    APIKeyRequired,
+    BatchSizeExceeded,
+    CharactersLimitExceeded,
+    InvalidLangCode,
+    ProviderError,
+    RequestError,
+    ServiceLimitReached,
+    UnexpectedError,
 )
 
 MODULES: dict[str, type[BaseProvider]] = {}

--- a/dialect/providers/base.py
+++ b/dialect/providers/base.py
@@ -133,7 +133,10 @@ class BaseProvider:
         Validate an instance of the provider.
 
         Args:
-            url: The instance URL to test, only hostname and tld, e.g. libretranslate.com, localhost
+            url: The instance URL to test, only hostname and tld, e.g. ``libretranslate.com``, ``localhost``.
+
+        Returns:
+            If the URL is a valid instance of the provider ot not.
         """
         raise NotImplementedError()
 
@@ -142,35 +145,33 @@ class BaseProvider:
         Validate an API key.
 
         Args:
-            key: The API key to validate
+            key: The API key to validate.
+
+        Returns:
+            If the API key is valid or not.
         """
         raise NotImplementedError()
 
     async def init_trans(self) -> None:
-        """
-        Initializes the provider translation capabilities.
-        """
+        """Initializes the provider translation capabilities."""
         raise NotImplementedError()
 
     async def init_tts(self) -> None:
-        """
-        Initializes the provider text-to-speech capabilities.
-
-        Args:
-            on_done: Called after the provider was successfully initialized
-            on_fail: Called after any error on initialization
-        """
+        """Initializes the provider text-to-speech capabilities."""
         raise NotImplementedError()
 
     async def translate(self, request: TranslationRequest) -> Translation:
         """
         Translates text in the provider.
 
-        Providers are expected to use `denormalize_lang` because `request`
-        will use normalized lang codes.
+        Providers are expected to use ``BaseProvider.denormalize_lang`` because
+        ``request`` will use normalized lang codes.
 
         Args:
-            request: The translation request
+            request: The translation request.
+
+        Returns:
+            A new translation object.
         """
         raise NotImplementedError()
 
@@ -178,36 +179,42 @@ class BaseProvider:
         """
         Sends a translation suggestion to the provider.
 
-        Providers are expected to use `denormalize_lang` because `src` and
-        `dest` will use normalized lang codes.
+        Providers are expected to use ``BaseProvider.denormalize_lang`` because
+        ``src`` and ``dest`` will use normalized lang codes.
 
         Args:
-            text: Original text without translation
-            src: The lang code of the original text
-            dest: The lang code of the translated text
-            suggestion: Suggested translation for text
+            text: Original text without translation.
+            src: The lang code of the original text.
+            dest: The lang code of the translated text.
+            suggestion: Suggested translation for text.
+
+        Returns:
+            If the suggestion was successful or not.
         """
         raise NotImplementedError()
 
     async def speech(self, text: str, language: str) -> IO:
         """
-        Generate speech audio from text
+        Generate speech audio from text.
 
-        Providers are expected to use `denormalize_lang` because `language`
-        will use normalized lang codes.
+        Providers are expected to use ``BaseProvider.denormalize_lang`` because
+        ``language`` will use normalized lang codes.
 
         Args:
-            text: Text to generate speech from
-            language: The lang code of text
+            text: Text to generate speech from.
+            language: The lang code of text.
+
+        Returns:
+            The file object with the speech audio written.
         """
         raise NotImplementedError()
 
     async def api_char_usage(self) -> tuple[int, int]:
         """
-        Retrieves the API usage status
+        Retrieves the API usage status.
 
         Returns:
-            The current usage and limit
+            The current usage and limit.
         """
         raise NotImplementedError()
 
@@ -215,14 +222,17 @@ class BaseProvider:
         """
         Compare two language codes.
 
-        It assumes that the codes have been normalized by `normalize_lang_code`
-        so providers might need to use `denormalize_lang` on `a` and `b`.
+        It assumes that the codes have been normalized by ``BaseProvider.normalize_lang_code``
+        so providers might need to use ``BaseProvider.denormalize_lang`` on ``a`` and ``b``.
 
         This method exists so providers can add additional comparison logic.
 
         Args:
-            a: First lang to compare
-            b: Second lang to compare
+            a: First lang to compare.
+            b: Second lang to compare.
+
+        Returns:
+            Whether both languages are equals in some way or not.
         """
 
         return a == b
@@ -230,6 +240,9 @@ class BaseProvider:
     def dest_langs_for(self, code: str) -> list[str]:
         """
         Get the available destination languages for a source language.
+
+        Returns:
+            The codes of available languages.
         """
         raise NotImplementedError()
 
@@ -238,15 +251,15 @@ class BaseProvider:
         """
         Mapping of Dialect/CLDR's lang codes to the provider ones.
 
-        Some providers might use different lang codes from the ones used by Dialect to for example get localized
-        language names.
+        Some providers might use different lang codes from the ones used by Dialect.
 
-        This dict is used by `add_lang` so lang codes can later be denormalized with `denormalize_lang`.
+        This dict is used by ``BaseProvider.add_lang`` so lang codes can later be denormalized with
+        ``BaseProvider.denormalize_lang``.
 
-        Codes must be formatted with the criteria from normalize_lang_code, because this value would be used by
-        `add_lang` after normalization.
+        Codes must be formatted with the criteria from ``BaseProvider.normalize_lang_code``, because this value would
+        be used by ``BaseProvider.add_lang`` after normalization.
 
-        Check `dialect.define.LANG_ALIASES` for reference mappings.
+        Check ``dialect.define.LANG_ALIASES`` for reference mappings.
         """
         return {}
 
@@ -292,7 +305,7 @@ class BaseProvider:
 
     @property
     def instance_url(self) -> str:
-        """Instance url saved on settings."""
+        """Instance url saved on settings"""
         return self.settings.instance_url
 
     @instance_url.setter
@@ -300,12 +313,12 @@ class BaseProvider:
         self.settings.instance_url = url
 
     def reset_instance_url(self):
-        """Resets saved instance url."""
+        """Resets saved instance url"""
         self.instance_url = ""
 
     @property
     def api_key(self) -> str:
-        """API key saved on settings."""
+        """API key saved on settings"""
         return self.settings.api_key
 
     @api_key.setter
@@ -318,7 +331,7 @@ class BaseProvider:
 
     @property
     def recent_src_langs(self) -> list[str]:
-        """Saved recent source langs of the user."""
+        """Saved recent source langs of the user"""
         return self.settings.src_langs
 
     @recent_src_langs.setter
@@ -331,7 +344,7 @@ class BaseProvider:
 
     @property
     def recent_dest_langs(self) -> list[str]:
-        """Saved recent destination langs of the user."""
+        """Saved recent destination langs of the user"""
         return self.settings.dest_langs
 
     @recent_dest_langs.setter
@@ -347,17 +360,20 @@ class BaseProvider:
     """
 
     @staticmethod
-    def format_url(url: str, path: str = "", params: dict = {}, http: bool = False):
+    def format_url(url: str, path: str = "", params: dict = {}, http: bool = False) -> str:
         """
         Compose a HTTP url with the given pieces.
 
-        If url is localhost, `http` is ignored and HTTP protocol is forced.
+        If url is "localhost", ``http`` is ignored and HTTP protocol is forced.
 
         Args:
-            url: Base url, hostname and tld
-            path: Path of the url
-            params: Params to populate a url query
-            http: If HTTP should be used instead of HTTPS
+            url: Base url, hostname and tld.
+            path: Path of the url.
+            params: Params to populate a url query.
+            http: If HTTP should be used instead of HTTPS.
+
+        Returns:
+            The new formatted URL.
         """
 
         if not path.startswith("/"):
@@ -373,21 +389,25 @@ class BaseProvider:
 
         return protocol + url + path + params_str
 
-    def normalize_lang_code(self, code: str):
+    def normalize_lang_code(self, code: str) -> str:
         """
-        Normalice a language code to Dialect's criteria.
+        Normalice a language code with Dialect's criteria.
+
+        This method also maps to lang codes aliases using ``BaseProvider.lang_aliases`` and
+        ``dialect.define.LANG_ALIASES``.
 
         Criteria:
-        - Codes must be lowercase, e.g. ES => es
-        - Codes can have a second code delimited by a hyphen, e.g. zh_CN => zh-CN
-        - If second code is two chars long it's considered a country code and must be uppercase, e.g. zh-cn => zh-CN
-        - If second code is four chars long it's considered a script code and must be capitalized,
-        e.g. zh-HANS => zh-Hans
-
-        This method also maps lang codes aliases using `lang_aliases` and `dialect.define.LANG_ALIASES`.
+            - Codes must be lowercase, e.g. ES => es
+            - Codes can have a second code delimited by a hyphen, e.g. zh_CN => zh-CN
+            - If second code is two chars long it's considered a country code and must be uppercase, e.g. zh-cn => zh-CN
+            - If second code is four chars long it's considered a script code and must be capitalized,
+            e.g. zh-HANS => zh-Hans
 
         Args:
-            code: Language ISO code
+            code: Language ISO code.
+
+        Returns:
+            The normalize language code.
         """
         code = code.replace("_", "-").lower()  # Normalize separator
         codes = code.split("-")
@@ -414,11 +434,12 @@ class BaseProvider:
         trans_src: bool = True,
         trans_dest: bool = True,
         tts: bool = False,
-    ):
+    ) -> None:
         """
-        Add lang supported by provider after normalization.
+        Register lang supported by the provider.
 
-        Normalized lang codes are saved for latter denormalization using `denormalize_lang`.
+        Lang codes are normalized and saved for latter denormalization using
+        ``BaseProvider.denormalize_lang``.
 
         Args:
             original_code: Lang code to add
@@ -442,21 +463,19 @@ class BaseProvider:
             self._nonstandard_langs[code] = original_code
 
         if name is not None and code not in self._languages_names:
-            # Save name provider by the service
+            # Save name provided by the service
             self._languages_names[code] = name
 
-    def denormalize_lang(self, *codes: str) -> str | tuple[str, ...]:
+    def denormalize_lang(self, *codes: str) -> tuple[str, ...]:
         """
         Get denormalized lang code if available.
 
-        This method will return a tuple with the same length of given codes or a str if only one code was passed.
-
         Args:
-        *codes: Lang codes to denormalize
-        """
+            *codes: Lang codes to denormalize
 
-        if len(codes) == 1:
-            return self._nonstandard_langs.get(codes[0], codes[0])
+        Returns:
+            The same amount of given codes but denormalized.
+        """
 
         result = []
         for code in codes:
@@ -467,10 +486,14 @@ class BaseProvider:
         """
         Get a localized language name.
 
-        Fallback to a name provided by the provider if available or ultimately just the code.
+        Fallback to a name provided by the provider if available or ultimately
+        just the code.
 
         Args:
             code: Language to get a name for
+
+        Returns:
+            The language name.
         """
         name = get_lang_name(code)  # Try getting translated name from Dialect
 

--- a/dialect/providers/base.py
+++ b/dialect/providers/base.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import urllib.parse
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum, Flag, auto
 from typing import IO
 
@@ -56,12 +56,31 @@ class ProvideLangModel(Enum):
 
 
 @dataclass
+class TranslationRequest:
+    text: str
+    src: str
+    dest: str
+
+
+@dataclass
+class TranslationMistake:
+    markup: str
+    text: str
+
+
+@dataclass
+class TranslationPronunciation:
+    src: str | None
+    dest: str | None
+
+
+@dataclass
 class Translation:
     text: str
-    original: tuple[str, str, str]
+    original: TranslationRequest
     detected: str | None = None
-    mistakes: tuple[str | None, str | None] = (None, None)
-    pronunciation: tuple[str | None, str | None] = (None, None)
+    mistakes: TranslationMistake | None = None
+    pronunciation: TranslationPronunciation = field(default_factory=lambda: TranslationPronunciation(None, None))
 
 
 class BaseProvider:
@@ -143,12 +162,7 @@ class BaseProvider:
         """
         raise NotImplementedError()
 
-    async def translate(
-        self,
-        text: str,
-        src: str,
-        dest: str,
-    ) -> Translation:
+    async def translate(self, request: TranslationRequest) -> Translation:
         """
         Translates text in the provider.
 

--- a/dialect/providers/base.py
+++ b/dialect/providers/base.py
@@ -229,6 +229,42 @@ class BaseProvider:
         return {}
 
     """
+    Provider features helpers
+    """
+
+    @property
+    def supports_instances(self) -> bool:
+        return ProviderFeature.INSTANCES in self.features
+
+    @property
+    def supports_api_key(self) -> bool:
+        return ProviderFeature.API_KEY in self.features
+
+    @property
+    def api_key_required(self) -> bool:
+        return ProviderFeature.API_KEY_REQUIRED in self.features
+
+    @property
+    def supports_api_usage(self) -> bool:
+        return ProviderFeature.API_KEY_USAGE in self.features
+
+    @property
+    def supports_detection(self) -> bool:
+        return ProviderFeature.DETECTION in self.features
+
+    @property
+    def supports_mistakes(self) -> bool:
+        return ProviderFeature.MISTAKES in self.features
+
+    @property
+    def supports_pronunciation(self) -> bool:
+        return ProviderFeature.PRONUNCIATION in self.features
+
+    @property
+    def supports_suggestions(self) -> bool:
+        return ProviderFeature.SUGGESTIONS in self.features
+
+    """
     Provider settings helpers and properties
     """
 

--- a/dialect/providers/base.py
+++ b/dialect/providers/base.py
@@ -166,16 +166,20 @@ class BaseProvider:
         """
         Translates text in the provider.
 
+        Providers are expected to use `denormalize_lang` because `request`
+        will use normalized lang codes.
+
         Args:
-            text: The text to translate
-            src: The lang code of the source text
-            dest: The lang code to translate the text to
+            request: The translation request
         """
         raise NotImplementedError()
 
     async def suggest(self, text: str, src: str, dest: str, suggestion: str) -> bool:
         """
         Sends a translation suggestion to the provider.
+
+        Providers are expected to use `denormalize_lang` because `src` and
+        `dest` will use normalized lang codes.
 
         Args:
             text: Original text without translation
@@ -188,6 +192,9 @@ class BaseProvider:
     async def speech(self, text: str, language: str) -> IO:
         """
         Generate speech audio from text
+
+        Providers are expected to use `denormalize_lang` because `language`
+        will use normalized lang codes.
 
         Args:
             text: Text to generate speech from
@@ -208,7 +215,8 @@ class BaseProvider:
         """
         Compare two language codes.
 
-        It assumes that the codes have been normalized by `normalize_lang_code`.
+        It assumes that the codes have been normalized by `normalize_lang_code`
+        so providers might need to use `denormalize_lang` on `a` and `b`.
 
         This method exists so providers can add additional comparison logic.
 

--- a/dialect/providers/errors.py
+++ b/dialect/providers/errors.py
@@ -1,0 +1,34 @@
+class RequestError(Exception):
+    """Exception raised when request fails."""
+
+
+class ProviderError(Exception):
+    """Exception raised when provider fails."""
+
+
+class UnexpectedError(ProviderError):
+    """Exception raised when provider fails."""
+
+
+class APIKeyRequired(ProviderError):
+    """Exception raised when provider fails."""
+
+
+class APIKeyInvalid(ProviderError):
+    """Exception raised when provider fails."""
+
+
+class InvalidLangCode(ProviderError):
+    """Exception raised when provider fails."""
+
+
+class BatchSizeExceeded(ProviderError):
+    """Exception raised when provider fails."""
+
+
+class CharactersLimitExceeded(ProviderError):
+    """Exception raised when provider fails."""
+
+
+class ServiceLimitReached(ProviderError):
+    """Exception raised when provider fails."""

--- a/dialect/providers/local.py
+++ b/dialect/providers/local.py
@@ -19,8 +19,8 @@ class LocalProvider(BaseProvider):
         Runs worker in a ThreadPoolExecutor.
 
         Args:
-            worker: Function to execute on the thread
-            *args: Args for the worker
+            worker: Function to execute on the thread.
+            *args: Args for the worker function.
         """
 
         loop = asyncio.get_running_loop()

--- a/dialect/providers/modules/bing.py
+++ b/dialect/providers/modules/bing.py
@@ -5,7 +5,7 @@ import re
 
 from bs4 import BeautifulSoup, Tag
 
-from dialect.providers.base import ProviderCapability, ProviderFeature, Translation
+from dialect.providers.base import ProviderCapability, ProviderFeature, Translation, TranslationPronunciation
 from dialect.providers.errors import ProviderError, UnexpectedError
 from dialect.providers.soup import SoupProvider
 
@@ -89,15 +89,15 @@ class Provider(SoupProvider):
         else:
             raise UnexpectedError("Could not get HTML from bing.com")
 
-    async def translate(self, text, src, dest):
+    async def translate(self, request):
         # Increment requests count
         self._count += 1
 
         # Form data
         data = {
-            "fromLang": "auto-detect" if src == "auto" else src,
-            "text": text,
-            "to": dest,
+            "fromLang": "auto-detect" if request.src == "auto" else request.src,
+            "text": request.text,
+            "to": request.dest,
             "token": self._token,
             "key": self._key,
         }
@@ -119,9 +119,9 @@ class Provider(SoupProvider):
 
                 return Translation(
                     data["translations"][0]["text"],
-                    (text, src, dest),
+                    request,
                     detected=detected,
-                    pronunciation=(None, pronunciation),
+                    pronunciation=TranslationPronunciation(None, pronunciation),
                 )
 
         except Exception as exc:

--- a/dialect/providers/modules/bing.py
+++ b/dialect/providers/modules/bing.py
@@ -90,14 +90,16 @@ class Provider(SoupProvider):
             raise UnexpectedError("Could not get HTML from bing.com")
 
     async def translate(self, request):
+        src, dest = self.denormalize_lang(request.src, request.dest)
+
         # Increment requests count
         self._count += 1
 
         # Form data
         data = {
-            "fromLang": "auto-detect" if request.src == "auto" else request.src,
+            "fromLang": "auto-detect" if src == "auto" else src,
             "text": request.text,
-            "to": request.dest,
+            "to": dest,
             "token": self._token,
             "key": self._key,
         }

--- a/dialect/providers/modules/deepl.py
+++ b/dialect/providers/modules/deepl.py
@@ -2,11 +2,7 @@
 # Copyright 2024 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from dialect.providers.base import (
-    ProviderCapability,
-    ProviderFeature,
-    Translation,
-)
+from dialect.providers.base import ProviderCapability, ProviderFeature, Translation
 from dialect.providers.errors import APIKeyInvalid, APIKeyRequired, ServiceLimitReached, UnexpectedError
 from dialect.providers.soup import SoupProvider
 
@@ -90,14 +86,14 @@ class Provider(SoupProvider):
         except Exception:
             raise
 
-    async def translate(self, text, src, dest):
+    async def translate(self, request):
         # Request body
         data = {
-            "text": [text],
-            "target_lang": dest,
+            "text": [request.text],
+            "target_lang": request.dest,
         }
-        if src != "auto":
-            data["source_lang"] = src
+        if request.src != "auto":
+            data["source_lang"] = request.src
 
         response = await self.post(self.translate_url, data, self.headers)
 
@@ -106,7 +102,7 @@ class Provider(SoupProvider):
             translations: list[dict[str, str]] | None = response.get("translations")
             if translations:
                 detected = translations[0].get("detected_source_language")
-                translation = Translation(translations[0]["text"], (text, src, dest), detected)
+                translation = Translation(translations[0]["text"], request, detected)
                 return translation
 
         raise UnexpectedError

--- a/dialect/providers/modules/deepl.py
+++ b/dialect/providers/modules/deepl.py
@@ -87,13 +87,15 @@ class Provider(SoupProvider):
             raise
 
     async def translate(self, request):
+        src, dest = self.denormalize_lang(request.src, request.dest)
+
         # Request body
         data = {
             "text": [request.text],
-            "target_lang": request.dest,
+            "target_lang": dest,
         }
-        if request.src != "auto":
-            data["source_lang"] = request.src
+        if src != "auto":
+            data["source_lang"] = src
 
         response = await self.post(self.translate_url, data, self.headers)
 

--- a/dialect/providers/modules/google.py
+++ b/dialect/providers/modules/google.py
@@ -532,7 +532,7 @@ class Provider(LocalProvider, SoupProvider):
         def get_speech():
             try:
                 file = NamedTemporaryFile()
-                lang = self.denormalize_lang(language)
+                (lang,) = self.denormalize_lang(language)
                 tts = gTTS(text, lang=lang, lang_check=False)
                 tts.write_to_fp(file)
                 file.seek(0)

--- a/dialect/providers/modules/libretrans.py
+++ b/dialect/providers/modules/libretrans.py
@@ -2,14 +2,18 @@
 # Copyright 2021 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import logging
-
 from dialect.providers.base import (
     ProviderCapability,
-    ProviderError,
-    ProviderErrorCode,
     ProviderFeature,
     Translation,
+)
+from dialect.providers.errors import (
+    APIKeyInvalid,
+    APIKeyRequired,
+    BatchSizeExceeded,
+    CharactersLimitExceeded,
+    InvalidLangCode,
+    UnexpectedError,
 )
 from dialect.providers.soup import SoupProvider
 
@@ -33,22 +37,6 @@ class Provider(SoupProvider):
 
         self.chars_limit = 0
 
-    def validate_instance(self, url, on_done, on_fail):
-        def on_response(data):
-            valid = False
-
-            try:
-                valid = data["info"]["title"] == "LibreTranslate"
-            except:  # noqa
-                pass
-
-            on_done(valid)
-
-        # Message request to LT API spec endpoint
-        message = self.create_message("GET", self.format_url(url, "/spec"))
-        # Do async request
-        self.send_and_read_and_process_response(message, on_response, on_fail, False)
-
     @property
     def frontend_settings_url(self):
         return self.format_url(self.instance_url, "/frontend/settings")
@@ -69,87 +57,53 @@ class Provider(SoupProvider):
     def translate_url(self):
         return self.format_url(self.instance_url, "/translate")
 
-    def init_trans(self, on_done, on_fail):
-        def check_finished():
-            self._init_count -= 1
+    async def validate_instance(self, url):
+        response = await self.get(self.format_url(url, "/spec"), check_common=False)
+        valid = False
 
-            if self._init_count == 0:
-                if self._init_error:
-                    on_fail(self._init_error)
-                else:
-                    on_done()
+        try:
+            valid = response["info"]["title"] == "LibreTranslate"
+        except:  # noqa
+            pass
 
-        def on_failed(error: ProviderError):
-            self._init_error = error
-            check_finished()
+        return valid
 
-        def on_languages_response(data):
-            try:
-                for lang in data:
-                    self.add_lang(lang["code"], lang["name"])
-
-                check_finished()
-
-            except Exception as exc:
-                logging.warning(exc)
-                on_failed(ProviderError(ProviderErrorCode.UNEXPECTED, str(exc)))
-
-        def on_settings_response(data):
-            try:
-                if data.get("suggestions", False):
-                    self.features ^= ProviderFeature.SUGGESTIONS
-                if data.get("apiKeys", False):
-                    self.features ^= ProviderFeature.API_KEY
-                if data.get("keyRequired", False):
-                    self.features ^= ProviderFeature.API_KEY_REQUIRED
-
-                self.chars_limit = int(data.get("charLimit", 0))
-
-                check_finished()
-
-            except Exception as exc:
-                logging.warning(exc)
-                on_failed(ProviderError(ProviderErrorCode.UNEXPECTED, str(exc)))
-
-        # Keep state of multiple request
-        self._init_count = 2
-        self._init_error: ProviderError | None = None
-
-        # Request messages
-        languages_message = self.create_message("GET", self.lang_url)
-        settings_message = self.create_message("GET", self.frontend_settings_url)
-
-        # Do async requests
-        self.send_and_read_and_process_response(languages_message, on_languages_response, on_failed)
-        self.send_and_read_and_process_response(settings_message, on_settings_response, on_failed)
-
-    def validate_api_key(self, key, on_done, on_fail):
-        def on_response(data):
-            valid = False
-            try:
-                valid = "confidence" in data[0]
-            except:  # noqa
-                pass
-
-            on_done(valid)
-
+    async def validate_api_key(self, key):
         # Form data
         data = {
             "q": "hello",
             "api_key": key,
         }
 
-        # Request message
-        message = self.create_message("POST", self.detect_url, data, form=True)
-        # Do async request
-        self.send_and_read_and_process_response(message, on_response, on_fail)
+        try:
+            response = await self.post(self.detect_url, data, form=True)
+            return "confidence" in response[0]
+        except (APIKeyInvalid, APIKeyRequired):
+            return False
+        except Exception:
+            raise
 
-    def translate(self, text, src, dest, on_done, on_fail):
-        def on_response(data):
-            detected = data.get("detectedLanguage", {}).get("language", None)
-            translation = Translation(data["translatedText"], (text, src, dest), detected)
-            on_done(translation)
+    async def init_trans(self):
+        languages = await self.get(self.lang_url)
+        settings = await self.get(self.frontend_settings_url)
 
+        try:
+            for lang in languages:
+                self.add_lang(lang["code"], lang["name"])
+
+            if settings.get("suggestions", False):
+                self.features ^= ProviderFeature.SUGGESTIONS
+            if settings.get("apiKeys", False):
+                self.features ^= ProviderFeature.API_KEY
+            if settings.get("keyRequired", False):
+                self.features ^= ProviderFeature.API_KEY_REQUIRED
+
+            self.chars_limit = int(settings.get("charLimit", 0))
+
+        except Exception as exc:
+            raise UnexpectedError from exc
+
+    async def translate(self, text, src, dest):
         # Request body
         data = {
             "q": text,
@@ -159,15 +113,15 @@ class Provider(SoupProvider):
         if self.api_key and ProviderFeature.API_KEY in self.features:
             data["api_key"] = self.api_key
 
-        # Request message
-        message = self.create_message("POST", self.translate_url, data)
-        # Do async request
-        self.send_and_read_and_process_response(message, on_response, on_fail)
+        # Do request
+        response = await self.post(self.translate_url, data)
+        try:
+            detected = response.get("detectedLanguage", {}).get("language", None)
+            return Translation(response["translatedText"], (text, src, dest), detected)
+        except Exception as exc:
+            raise UnexpectedError from exc
 
-    def suggest(self, text, src, dest, suggestion, on_done, on_fail):
-        def on_response(data):
-            on_done(data.get("success", False))
-
+    async def suggest(self, text, src, dest, suggestion):
         # Form data
         data = {
             "q": text,
@@ -178,28 +132,29 @@ class Provider(SoupProvider):
         if self.api_key and ProviderFeature.API_KEY in self.features:
             data["api_key"] = self.api_key
 
-        # Request message
-        message = self.create_message("POST", self.suggest_url, data, form=True)
-        # Do async request
-        self.send_and_read_and_process_response(message, on_response, on_fail)
+        # Do request
+        response = await self.post(self.suggest_url, data, form=True)
+        try:
+            return response.get("success", False)
+        except:  # noqa
+            return False
 
     def check_known_errors(self, _status, data):
         if not data:
-            return ProviderError(ProviderErrorCode.EMPTY, "Response is empty!")
+            raise UnexpectedError("Response is empty!")
+
         if "error" in data:
             error = data["error"]
 
             if error == "Please contact the server operator to obtain an API key":
-                return ProviderError(ProviderErrorCode.API_KEY_REQUIRED, error)
+                raise APIKeyRequired(error)
             elif error == "Invalid API key":
-                return ProviderError(ProviderErrorCode.API_KEY_INVALID, error)
+                raise APIKeyInvalid(error)
             elif "is not supported" in error:
-                return ProviderError(ProviderErrorCode.INVALID_LANG_CODE, error)
+                raise InvalidLangCode(error)
             elif "exceeds text limit" in error:
-                return ProviderError(ProviderErrorCode.BATCH_SIZE_EXCEEDED, error)
+                raise BatchSizeExceeded(error)
             elif "exceeds character limit" in error:
-                return ProviderError(ProviderErrorCode.CHARACTERS_LIMIT_EXCEEDED, error)
-            elif "Cannot translate text" in error or "format is not supported" in error:
-                return ProviderError(ProviderErrorCode.TRANSLATION_FAILED, error)
+                raise CharactersLimitExceeded(error)
             else:
-                return ProviderError(ProviderErrorCode.UNEXPECTED, error)
+                raise UnexpectedError(error)

--- a/dialect/providers/modules/libretrans.py
+++ b/dialect/providers/modules/libretrans.py
@@ -103,12 +103,12 @@ class Provider(SoupProvider):
         except Exception as exc:
             raise UnexpectedError from exc
 
-    async def translate(self, text, src, dest):
+    async def translate(self, request):
         # Request body
         data = {
-            "q": text,
-            "source": src,
-            "target": dest,
+            "q": request.text,
+            "source": request.src,
+            "target": request.dest,
         }
         if self.api_key and ProviderFeature.API_KEY in self.features:
             data["api_key"] = self.api_key
@@ -117,7 +117,7 @@ class Provider(SoupProvider):
         response = await self.post(self.translate_url, data)
         try:
             detected = response.get("detectedLanguage", {}).get("language", None)
-            return Translation(response["translatedText"], (text, src, dest), detected)
+            return Translation(response["translatedText"], request, detected)
         except Exception as exc:
             raise UnexpectedError from exc
 

--- a/dialect/providers/modules/libretrans.py
+++ b/dialect/providers/modules/libretrans.py
@@ -104,11 +104,13 @@ class Provider(SoupProvider):
             raise UnexpectedError from exc
 
     async def translate(self, request):
+        src, dest = self.denormalize_lang(request.src, request.dest)
+
         # Request body
         data = {
             "q": request.text,
-            "source": request.src,
-            "target": request.dest,
+            "source": src,
+            "target": dest,
         }
         if self.api_key and ProviderFeature.API_KEY in self.features:
             data["api_key"] = self.api_key
@@ -122,6 +124,8 @@ class Provider(SoupProvider):
             raise UnexpectedError from exc
 
     async def suggest(self, text, src, dest, suggestion):
+        src, dest = self.denormalize_lang(src, dest)
+
         # Form data
         data = {
             "q": text,

--- a/dialect/providers/modules/lingva.py
+++ b/dialect/providers/modules/lingva.py
@@ -80,9 +80,10 @@ class Provider(SoupProvider):
         await self.init()
 
     async def translate(self, request):
+        src, dest = self.denormalize_lang(request.src, request.dest)
         # Format url query data
         text = quote(request.text, safe="")
-        url = self.translate_url.format(text=text, src=request.src, dest=request.dest)
+        url = self.translate_url.format(text=text, src=src, dest=dest)
 
         # Do request
         response = await self.get(url)
@@ -104,6 +105,7 @@ class Provider(SoupProvider):
             raise UnexpectedError("Failed reading the translation data") from exc
 
     async def speech(self, text, language):
+        language = self.denormalize_lang(language)
         # Format url query data
         url = self.speech_url.format(text=text, lang=language)
         # Do request

--- a/dialect/providers/modules/lingva.py
+++ b/dialect/providers/modules/lingva.py
@@ -105,7 +105,7 @@ class Provider(SoupProvider):
             raise UnexpectedError("Failed reading the translation data") from exc
 
     async def speech(self, text, language):
-        language = self.denormalize_lang(language)
+        (language,) = self.denormalize_lang(language)
         # Format url query data
         url = self.speech_url.format(text=text, lang=language)
         # Do request

--- a/dialect/providers/modules/lingva.py
+++ b/dialect/providers/modules/lingva.py
@@ -2,17 +2,15 @@
 # Copyright 2021 Rafael Mardojai CM
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import logging
 from tempfile import NamedTemporaryFile
 from urllib.parse import quote
 
 from dialect.providers.base import (
     ProviderCapability,
-    ProviderError,
-    ProviderErrorCode,
     ProviderFeature,
     Translation,
 )
+from dialect.providers.errors import InvalidLangCode, UnexpectedError
 from dialect.providers.soup import SoupProvider
 
 
@@ -37,21 +35,6 @@ class Provider(SoupProvider):
 
         self.chars_limit = 5000
 
-    def validate_instance(self, url, on_done, on_fail):
-        def on_response(data):
-            valid = False
-            try:
-                valid = "translation" in data
-            except:  # noqa
-                pass
-
-            on_done(valid)
-
-        # Lingva translation endpoint
-        message = self.create_message("GET", self.format_url(url, "/api/v1/en/es/hello"))
-        # Do async request
-        self.send_and_read_and_process_response(message, on_response, on_fail, False)
-
     @property
     def lang_url(self):
         return self.format_url(self.instance_url, "/api/v1/languages/")
@@ -64,89 +47,85 @@ class Provider(SoupProvider):
     def speech_url(self):
         return self.format_url(self.instance_url, "/api/v1/audio/{lang}/{text}")
 
-    def init(self, on_done, on_fail):
-        def on_response(data):
-            if "languages" in data:
-                for lang in data["languages"]:
+    async def validate_instance(self, url):
+        request = await self.get(self.format_url(url, "/api/v1/en/es/hello"), check_common=False)
+
+        valid = False
+        try:
+            valid = "translation" in request
+        except:  # noqa
+            pass
+
+        return valid
+
+    async def init(self) -> None:
+        response = await self.get(self.lang_url)
+
+        try:
+            if "languages" in response:
+                for lang in response["languages"]:
                     if lang["code"] != "auto":
                         self.add_lang(lang["code"], lang["name"], tts=True)
-                on_done()
             else:
-                on_fail(ProviderError(ProviderErrorCode.UNEXPECTED, "No langs found in server."))
+                raise UnexpectedError("No langs found in server.")
+        except Exception as exc:
+            raise UnexpectedError from exc
 
-        # Languages message request
-        message = self.create_message("GET", self.lang_url)
-        # Do async request
-        self.send_and_read_and_process_response(message, on_response, on_fail)
+    async def init_trans(self):
+        await self.init()
 
-    def init_trans(self, on_done, on_fail):
-        self.init(on_done, on_fail)
+    async def init_tts(self):
+        await self.init()
 
-    def init_tts(self, on_done, on_fail):
-        self.init(on_done, on_fail)
-
-    def translate(self, text, src, dest, on_done, on_fail):
-        def on_response(data):
-            try:
-                detected = data.get("info", {}).get("detectedSource", None)
-                mistakes = data.get("info", {}).get("typo", None)
-                src_pronunciation = data.get("info", {}).get("pronunciation", {}).get("query", None)
-                dest_pronunciation = data.get("info", {}).get("pronunciation", {}).get("translation", None)
-
-                translation = Translation(
-                    data["translation"],
-                    (text, src, dest),
-                    detected,
-                    (mistakes, mistakes),
-                    (src_pronunciation, dest_pronunciation),
-                )
-
-                on_done(translation)
-
-            except Exception as exc:
-                error = "Failed reading the translation data"
-                logging.warning(error, exc)
-                on_fail(ProviderError(ProviderErrorCode.TRANSLATION_FAILED, error))
-
+    async def translate(self, text, src, dest):
         # Format url query data
         text = quote(text, safe="")
         url = self.translate_url.format(text=text, src=src, dest=dest)
 
-        # Request message
-        message = self.create_message("GET", url)
+        # Do request
+        response = await self.get(url)
+        try:
+            detected = response.get("info", {}).get("detectedSource", None)
+            mistakes = response.get("info", {}).get("typo", None)
+            src_pronunciation = response.get("info", {}).get("pronunciation", {}).get("query", None)
+            dest_pronunciation = response.get("info", {}).get("pronunciation", {}).get("translation", None)
 
-        # Do async request
-        self.send_and_read_and_process_response(message, on_response, on_fail)
+            return Translation(
+                response["translation"],
+                (text, src, dest),
+                detected,
+                (mistakes, mistakes),
+                (src_pronunciation, dest_pronunciation),
+            )
 
-    def speech(self, text, language, on_done, on_fail):
-        def on_response(data):
-            if "audio" in data:
-                file = NamedTemporaryFile()
-                audio = bytearray(data["audio"])
-                file.write(audio)
-                file.seek(0)
+        except Exception as exc:
+            raise UnexpectedError("Failed reading the translation data") from exc
 
-                on_done(file)
-            else:
-                on_fail(ProviderError(ProviderErrorCode.TTS_FAILED, "No audio was found."))
-
+    async def speech(self, text, language):
         # Format url query data
         url = self.speech_url.format(text=text, lang=language)
+        # Do request
+        response = await self.get(url)
 
-        # Request message
-        message = self.create_message("GET", url)
-
-        # Do async request
-        self.send_and_read_and_process_response(message, on_response, on_fail)
+        try:
+            file = NamedTemporaryFile()
+            audio = bytearray(response["audio"])
+            file.write(audio)
+            file.seek(0)
+            return file
+        except Exception as exc:
+            file.close()
+            raise UnexpectedError from exc
 
     def check_known_errors(self, _status, data):
         """Raises a proper Exception if an error is found in the data."""
         if not data:
-            return ProviderError(ProviderErrorCode.EMPTY, "Response is empty!")
+            raise UnexpectedError("Response is empty!")
+
         if "error" in data:
             error = data["error"]
 
             if error == "Invalid target language" or error == "Invalid source language":
-                return ProviderError(ProviderErrorCode.INVALID_LANG_CODE, error)
+                raise InvalidLangCode(error)
             else:
-                return ProviderError(ProviderErrorCode.UNEXPECTED, error)
+                raise UnexpectedError(error)

--- a/dialect/providers/modules/lingva.py
+++ b/dialect/providers/modules/lingva.py
@@ -9,6 +9,8 @@ from dialect.providers.base import (
     ProviderCapability,
     ProviderFeature,
     Translation,
+    TranslationMistake,
+    TranslationPronunciation,
 )
 from dialect.providers.errors import InvalidLangCode, UnexpectedError
 from dialect.providers.soup import SoupProvider
@@ -77,10 +79,10 @@ class Provider(SoupProvider):
     async def init_tts(self):
         await self.init()
 
-    async def translate(self, text, src, dest):
+    async def translate(self, request):
         # Format url query data
-        text = quote(text, safe="")
-        url = self.translate_url.format(text=text, src=src, dest=dest)
+        text = quote(request.text, safe="")
+        url = self.translate_url.format(text=text, src=request.src, dest=request.dest)
 
         # Do request
         response = await self.get(url)
@@ -92,10 +94,10 @@ class Provider(SoupProvider):
 
             return Translation(
                 response["translation"],
-                (text, src, dest),
+                request,
                 detected,
-                (mistakes, mistakes),
-                (src_pronunciation, dest_pronunciation),
+                TranslationMistake(mistakes, mistakes) if mistakes else None,
+                TranslationPronunciation(src_pronunciation, dest_pronunciation),
             )
 
         except Exception as exc:

--- a/dialect/providers/modules/yandex.py
+++ b/dialect/providers/modules/yandex.py
@@ -149,10 +149,11 @@ class Provider(SoupProvider):
         return self.format_url("translate.yandex.net", path)
 
     async def translate(self, request):
+        src, dest = self.denormalize_lang(request.src, request.dest)
         # Form data
-        data = {"lang": request.dest, "text": request.text}
-        if request.src != "auto":
-            data["lang"] = f"{request.src}-{request.dest}"
+        data = {"lang": dest, "text": request.text}
+        if src != "auto":
+            data["lang"] = f"{src}-{dest}"
 
         # Do request
         response = await self.post(self.translate_url, data, self._headers, True)

--- a/dialect/providers/modules/yandex.py
+++ b/dialect/providers/modules/yandex.py
@@ -148,11 +148,11 @@ class Provider(SoupProvider):
         path = f"/api/v1/tr.json/translate?id={self._uuid}-0-0&srv=android"
         return self.format_url("translate.yandex.net", path)
 
-    async def translate(self, text, src, dest):
+    async def translate(self, request):
         # Form data
-        data = {"lang": dest, "text": text}
-        if src != "auto":
-            data["lang"] = f"{src}-{dest}"
+        data = {"lang": request.dest, "text": request.text}
+        if request.src != "auto":
+            data["lang"] = f"{request.src}-{request.dest}"
 
         # Do request
         response = await self.post(self.translate_url, data, self._headers, True)
@@ -161,7 +161,7 @@ class Provider(SoupProvider):
             if "code" in response and response["code"] == 200:
                 if "lang" in response:
                     detected = response["lang"].split("-")[0]
-                return Translation(response["text"][0], (text, src, dest), detected)
+                return Translation(response["text"][0], request, detected)
             else:
                 error = response["message"] if "message" in response else ""
                 raise ProviderError(error)

--- a/dialect/providers/soup.py
+++ b/dialect/providers/soup.py
@@ -24,7 +24,10 @@ class SoupProvider(BaseProvider):
         Convert Python data to JSON and bytes.
 
         Args:
-            data: Data to encode, anything json.dumps can handle
+            data: Data to encode, anything json.dumps can handle.
+
+        Returns:
+            The GLib Bytes or None if something failed.
         """
         data_glib_bytes = None
         try:
@@ -38,17 +41,19 @@ class SoupProvider(BaseProvider):
         self, method: str, url: str, data: Any = {}, headers: dict = {}, form: bool = False
     ) -> Soup.Message:
         """
-        Create a libsoup's message.
+        Create a Soup's message.
 
         Encodes data and adds it to the message as the request body.
-        If form is true, data is encoded as application/x-www-form-urlencoded.
 
         Args:
-            method: HTTP method of the message
-            url: Url of the message
-            data: Request body or form data
-            headers: HTTP headers of the message
-            form: If the data should be encoded as a form
+            method: HTTP method of the message.
+            url: Url of the message.
+            data: Request body or form data.
+            headers: HTTP headers of the message.
+            form: If the data should be encoded as ``application/x-www-form-urlencoded``.
+
+        Returns:
+            The Soup Message for the given parameters.
         """
 
         if form and data:
@@ -71,20 +76,26 @@ class SoupProvider(BaseProvider):
 
     async def send_and_read(self, message: Soup.Message) -> bytes | None:
         """
-        Helper method for libsoup's send_and_read_async.
+        Helper method for Soup's send_and_read_async.
 
         Args:
-            message: Message to send
+            message: Message to send.
+
+        Returns:
+            The bytes of the response or None.
         """
         response: GLib.Bytes = await Session.get().send_and_read_async(message, 0)  # type: ignore
         return response.get_data()
 
     async def send_and_read_json(self, message: Soup.Message) -> Any:
         """
-        Like `SoupProvider.send_and_read` but returns JSON parsed
+        Like ``SoupProvider.send_and_read`` but returns JSON parsed.
 
         Args:
-            message: Message to send
+            message: Message to send.
+
+        Returns:
+            The JSON of the response deserialized to a python object.
         """
         response = await self.send_and_read(message)
         return json.loads(response) if response else {}
@@ -96,8 +107,8 @@ class SoupProvider(BaseProvider):
         This should be implemented by subclases.
 
         Args:
-            status: HTTP status
-            data: Response body data
+            status: HTTP status.
+            data: Response body data.
         """
 
     async def send_and_read_and_process(
@@ -107,13 +118,18 @@ class SoupProvider(BaseProvider):
         json: bool = True,
     ) -> Any:
         """
-        Helper mixing `send_and_read`, `send_and_read_json` and `check_known_errors`.
+        Helper mixing ``SoupProvider.send_and_read``, ``SoupProvider.send_and_read_json``
+        and ``SoupProvider.check_known_errors``.
 
         Converts `GLib.Error` to `RequestError`.
 
-        message: Message to send
-        check_common: If response data should be checked for errors using check_known_errors
-        json: If data should be processed as JSON
+        Args:
+            message: Message to send.
+            check_common: If response data should be checked for errors using check_known_errors.
+            json: If data should be processed as JSON.
+
+        Returns:
+            The JSON deserialized to a python object or bytes if ``json`` is ``False``.
         """
 
         try:
@@ -142,13 +158,17 @@ class SoupProvider(BaseProvider):
         """
         Helper for regular HTTP request.
 
-        method: HTTP method of the request
-        url: Url of the request
-        data: Request body or form data
-        headers: HTTP headers of the message
-        form: If the data should be encoded as a form
-        check_common: If response data should be checked for errors using check_known_errors
-        json: If data should be processed as JSON
+        Args:
+            method: HTTP method of the request.
+            url: Url of the request.
+            data: Request body or form data.
+            headers: HTTP headers of the message.
+            form: If the data should be encoded as a form.
+            check_common: If response data should be checked for errors using check_known_errors.
+            json: If data should be processed as JSON.
+
+        Returns:
+            The JSON deserialized to a python object or bytes if ``json`` is ``False``.
         """
         message = self.create_message(method, url, data, headers, form)
         return await self.send_and_read_and_process(message, check_common, json)
@@ -164,11 +184,15 @@ class SoupProvider(BaseProvider):
         """
         Helper for GET HTTP request.
 
-        url: Url of the request
-        headers: HTTP headers of the message
-        form: If the data should be encoded as a form
-        check_common: If response data should be checked for errors using check_known_errors
-        json: If data should be processed as JSON
+        Args:
+            url: Url of the request.
+            headers: HTTP headers of the message.
+            form: If the data should be encoded as a form.
+            check_common: If response data should be checked for errors using check_known_errors.
+            json: If data should be processed as JSON.
+
+        Returns:
+            The JSON deserialized to a python object or bytes if ``json`` is ``False``.
         """
         return await self.request("GET", url, headers=headers, form=form, check_common=check_common, json=json)
 
@@ -184,11 +208,15 @@ class SoupProvider(BaseProvider):
         """
         Helper for POST HTTP request.
 
-        url: Url of the request
-        data: Request body or form data
-        headers: HTTP headers of the message
-        form: If the data should be encoded as a form
-        check_common: If response data should be checked for errors using check_known_errors
-        json: If data should be processed as JSON
+        Args:
+            url: Url of the request.
+            data: Request body or form data.
+            headers: HTTP headers of the message.
+            form: If the data should be encoded as a form.
+            check_common: If response data should be checked for errors using check_known_errors.
+            json: If data should be processed as JSON.
+
+        Returns:
+            The JSON deserialized to a python object or bytes if ``json`` is ``False``.
         """
         return await self.request("POST", url, data, headers, form, check_common, json)

--- a/dialect/search_provider/search_provider.in
+++ b/dialect/search_provider/search_provider.in
@@ -9,7 +9,9 @@
 import gettext
 import locale
 import sys
-from typing import Callable
+import inspect
+import logging
+from typing import Any, Callable, Coroutine
 
 import gi
 
@@ -17,8 +19,15 @@ gi.require_version("Secret", "1")
 gi.require_version("Soup", "3.0")
 from gi.repository import Gio, GLib
 
-from dialect.providers import TRANSLATORS
-from dialect.providers.base import ProviderErrorCode
+from dialect.asyncio import create_background_task, glib_event_loop_policy
+from dialect.providers import (
+    TRANSLATORS,
+    TranslationRequest,
+    ProviderError,
+    RequestError,
+    APIKeyInvalid,
+    APIKeyRequired,
+)
 from dialect.settings import Settings
 
 CLIPBOARD_PREFIX = "copy-to-clipboard"
@@ -77,17 +86,12 @@ class TranslateServiceApplication(Gio.Application):
         self.search_interface = Gio.DBusNodeInfo.new_for_xml(dbus_interface_description).interfaces[0]
 
         self.loaded = False
-        self.load_failed = False
-
-        # Translations store
-        self.translations = {}
+        self.translations = {}  # Translations store
         self.src_language = "auto"
         self.dest_language = None
 
         # Translator
-        self._load_translator()
-        Settings.get().connect("changed", self._on_settings_changed)
-        Settings.get().connect("translator-changed", self._on_translator_changed)
+        Settings.get().connect("provider-changed::translator", self._on_translator_changed)
 
     def do_dbus_register(self, connection, object_path):
         try:
@@ -112,7 +116,8 @@ class TranslateServiceApplication(Gio.Application):
         parameters: GLib.Variant,
         invocation: Gio.DBusMethodInvocation,
     ):
-        def return_value(results):
+
+        def wrap_results(results: Any) -> GLib.Variant:
             results = (results,)
             if results == (None,):
                 results = ()
@@ -126,78 +131,82 @@ class TranslateServiceApplication(Gio.Application):
                 )
                 + ")"
             )
-            wrapped_results = GLib.Variant(results_type, results)
 
-            invocation.return_value(wrapped_results)
+            return GLib.Variant(results_type, results)
+
+        async def return_async_value(method: Callable[..., Coroutine], *args):
+            results = wrap_results(await method(*args))
+            self.release()
+            invocation.return_value(results)
 
         method = getattr(self, method_name)
-        arguments = list(parameters.unpack())
-        arguments.append(return_value)
+        args = list(parameters.unpack())
 
-        method(*arguments)
+        if inspect.iscoroutinefunction(method):  # Async methods
+            create_background_task(return_async_value(method, *args))
+            self.hold()
+        else:  # Sync methods
+            results = wrap_results(method(*args))
+            invocation.return_value(results)
 
     @property
     def live_enabled(self) -> bool:
         return Settings.get().live_translation and Settings.get().sp_translation
 
-    def GetInitialResultSet(self, terms: list[str], callback: Callable[[list[str]], None]):
+    async def GetInitialResultSet(self, terms: list[str]) -> list[str]:
         """
         Join separate terms in one ID line, start translation and send this line back
         on start of input
         """
-
-        def on_done(translation):
-            self.translations[text] = translation.text
-            callback([text, CLIPBOARD_PREFIX + text])
-            self.release()
-
-        def on_fail(error):
-            match error.code:
-                case ProviderErrorCode.NETWORK:
-                    self.translations[error_id] = _("Translation failed, check for network issues")
-                case ProviderErrorCode.API_KEY_INVALID:
-                    self.translations[error_id] = _("The provided API key is invalid")
-                case ProviderErrorCode.API_KEY_REQUIRED:
-                    self.translations[error_id] = _("API key is required to use the service")
-                case _:
-                    self.translations[error_id] = _("Translation failed")
-            callback([error_id])
-            self.release()
-
         text = " ".join(terms)
 
         if self.live_enabled:
             error_id = ERROR_PREFIX + text
 
-            if self.load_failed:
-                self.translations[error_id] = _("Failed loading the translation service")
-                callback([error_id])
-            elif not self.loaded:
-                return self.GetInitialResultSet(terms, callback)
+            # Load the translator if needed
+            # TODO: Verify API key when needed
+            if not self.loaded:
+                try:
+                    await self._load_translator()
+                except Exception:
+                    self.translations[error_id] = _("Failed loading the translation service")
+                    return [error_id]
 
             # If the two languages are the same, nothing is done
             if self.dest_language and self.src_language != self.dest_language and text != "":
                 src, dest = self.translator.denormalize_lang(self.src_language, self.dest_language)
-                self.translator.translate(text, src, dest, on_done, on_fail)
-                self.hold()
+                request = TranslationRequest(text, src, dest)
 
+                try:
+                    translation = await self.translator.translate(request)
+                    self.translations[text] = translation.text
+                    return [text, CLIPBOARD_PREFIX + text]
+                except (RequestError, ProviderError) as exc:
+                    logging.error(exc)
+
+                    if isinstance(exc, RequestError):
+                        self.translations[error_id] = _("Translation failed, check for network issues")
+                    elif isinstance(exc, APIKeyInvalid):
+                        self.translations[error_id] = _("The provided API key is invalid")
+                    elif isinstance(exc, APIKeyRequired):
+                        self.translations[error_id] = _("API key is required to use the service")
+                    else:
+                        self.translations[error_id] = _("Translation failed")
+
+                    return [error_id]
+            else:
+                return []
         else:
-            provider = Settings.get().active_translator
+            return [
+                _("Translate “{text}” with {provider_name}").format(
+                    text=text, provider_name=TRANSLATORS[Settings.get().active_translator].prettyname
+                )
+            ]
 
-            callback(
-                [
-                    _("Translate “{text}” with {provider_name}").format(
-                        text=text, provider_name=TRANSLATORS[provider].prettyname
-                    )
-                ]
-            )
+    async def GetSubsearchResultSet(self, _previous_results: list[str], new_terms: list[str]) -> list[str]:
+        return await self.GetInitialResultSet(new_terms)
 
-    def GetSubsearchResultSet(
-        self, _previous_results: list[str], new_terms: list[str], callback: Callable[[list[str]], None]
-    ):
-        self.GetInitialResultSet(new_terms, callback)
-
-    def GetResultMetas(self, ids: list[str], callback: Callable[[list[dict[str, GLib.Variant]]], None]):
+    def GetResultMetas(self, ids: list[str]) -> list[dict[str, GLib.Variant]]:
         """Send translated text"""
 
         translate_id = ids[0]
@@ -207,14 +216,12 @@ class TranslateServiceApplication(Gio.Application):
             if translate_id in self.translations:
                 text = self.translations[translate_id]
 
-            callback(
-                [
-                    {
-                        "id": GLib.Variant("s", translate_id),
-                        "name": GLib.Variant("s", text),
-                    }
-                ]
-            )
+            return [
+                {
+                    "id": GLib.Variant("s", translate_id),
+                    "name": GLib.Variant("s", text),
+                }
+            ]
 
         elif len(ids) == 2 and translate_id in self.translations and ids[1] == CLIPBOARD_PREFIX + ids[0]:
             text = self.translations[translate_id]
@@ -227,80 +234,73 @@ class TranslateServiceApplication(Gio.Application):
 
             self.translations.clear()
 
-            callback(
-                [
-                    {
-                        "id": GLib.Variant("s", translate_id),
-                        "name": GLib.Variant("s", text),
-                        "description": GLib.Variant("s", description),
-                    },
-                    {
-                        "id": GLib.Variant("s", ids[1]),
-                        "name": GLib.Variant("s", _("Copy")),
-                        "description": GLib.Variant("s", _("Copy translation to clipboard")),
-                        "clipboardText": GLib.Variant("s", text),
-                    },
-                ]
-            )
+            return [
+                {
+                    "id": GLib.Variant("s", translate_id),
+                    "name": GLib.Variant("s", text),
+                    "description": GLib.Variant("s", description),
+                },
+                {
+                    "id": GLib.Variant("s", ids[1]),
+                    "name": GLib.Variant("s", _("Copy")),
+                    "description": GLib.Variant("s", _("Copy translation to clipboard")),
+                    "clipboardText": GLib.Variant("s", text),
+                },
+            ]
 
         else:
             # Probably never needed, just in case
-            callback(
-                [
-                    dict(
-                        id=GLib.Variant("s", id),
-                        name=GLib.Variant("s", id),
-                    )
-                    for id in ids
-                ]
-            )
+            return [
+                dict(
+                    id=GLib.Variant("s", id),
+                    name=GLib.Variant("s", id),
+                )
+                for id in ids
+            ]
 
-    def ActivateResult(self, result_id: str, terms: list[str], timestamp: int, callback: Callable):
+    def ActivateResult(self, result_id: str, terms: list[str], timestamp: int):
         if not result_id.startswith(CLIPBOARD_PREFIX):
-            self.LaunchSearch(terms, timestamp, callback)
-        else:
-            callback((None,))
+            self.LaunchSearch(terms, timestamp)
 
-    def LaunchSearch(self, terms: list[str], _timestamp: int, callback: Callable):
+    def LaunchSearch(self, terms: list[str], _timestamp: int):
         text = " ".join(terms)
         GLib.spawn_async_with_pipes(None, ["@BIN@", "--text", text], None, GLib.SpawnFlags.SEARCH_PATH, None)
 
-        callback((None,))
+    async def _load_translator(self):
+        if self.loaded:
+            return
 
-    def _load_translator(self):
-        def on_done():
-            self.loaded = True
-            self.load_failed = False
-            self.dest_language = self.translator.recent_dest_langs[0]
-
-            self.translator.settings.connect("changed", self._on_translator_settings_changed)
-
-        def on_fail(_error):
-            self.loaded = False
-            self.load_failed = True
-            self.dest_language = None
-
-        self.loaded = False
-        provider = Settings.get().active_translator
-        self.translator = TRANSLATORS[provider]()
+        self.translator = TRANSLATORS[Settings.get().active_translator]()
 
         # Init translator
-        self.translator.init_trans(on_done, on_fail)
+        try:
+            await self.translator.init_trans()
 
-    def _on_settings_changed(self, _settings, key: str):
-        if key.startswith("translator-"):
-            self._load_translator()
+            self.loaded = True
+            self.dest_language = self.translator.recent_dest_langs[0]
+            self.translator.settings.connect("changed", self._on_translator_settings_changed)
+
+        except Exception:
+            self.dest_language = None
+            raise
 
     def _on_translator_changed(self, *args):
-        self._load_translator()
+        self.loaded = False
 
     def _on_translator_settings_changed(self, _settings, key: str):
         if key == "src-langs" or key == "dest-langs":
             self.dest_language = self.translator.recent_dest_langs[0]
         else:
-            self._load_translator()
+            self.loaded = False
+
+
+def main():
+    app = TranslateServiceApplication()
+    exit_code = 0
+    with glib_event_loop_policy():
+        exit_code = app.run(None)
+    return exit_code
 
 
 if __name__ == "__main__":
-    app = TranslateServiceApplication()
-    sys.exit(app.run(None))
+    sys.exit(main())

--- a/dialect/settings.py
+++ b/dialect/settings.py
@@ -43,11 +43,8 @@ class Settings(Gio.Settings):
             Settings.instance = Settings.new()
         return Settings.instance
 
-    @GObject.Signal(arg_types=(str,))
-    def translator_changed(self, _name: str): ...
-
-    @GObject.Signal(arg_types=(str,))
-    def tts_changed(self, _name: str): ...
+    @GObject.Signal(flags=GObject.SignalFlags.DETAILED, arg_types=(str, str))
+    def provider_changed(self, name: str): ...
 
     @property
     def translators_list(self) -> list[str]:
@@ -70,7 +67,7 @@ class Settings(Gio.Settings):
     @active_translator.setter
     def active_translator(self, translator: str):
         self._translators.set_string("active", translator)
-        self.emit("translator-changed", translator)
+        self.emit("provider-changed::translator", "translator", translator)
 
     @property
     def window_size(self) -> tuple[int, int]:
@@ -143,7 +140,7 @@ class Settings(Gio.Settings):
     def active_tts(self, tts: str):
         """Set the user's preferred TTS service."""
         self._tts.set_string("active", tts)
-        self.emit("tts-changed", tts)
+        self.emit("provider-changed::tts", "tts", tts)
 
     @property
     def color_scheme(self) -> str:

--- a/dialect/widgets/provider_preferences.py
+++ b/dialect/widgets/provider_preferences.py
@@ -12,7 +12,7 @@ from gi.repository import Adw, GObject, Gtk
 
 from dialect.asyncio import create_background_task
 from dialect.define import RES_PATH
-from dialect.providers import ProviderCapability, ProviderFeature, RequestError
+from dialect.providers import ProviderCapability, RequestError
 
 if typing.TYPE_CHECKING:
     from dialect.window import DialectWindow
@@ -69,11 +69,11 @@ class ProviderPreferences(Adw.NavigationPage):
         if not self.provider:
             return
 
-        self.instance_entry.props.visible = ProviderFeature.INSTANCES in self.provider.features
-        self.api_key_entry.props.visible = ProviderFeature.API_KEY in self.provider.features
+        self.instance_entry.props.visible = self.provider.supports_instances
+        self.api_key_entry.props.visible = self.provider.supports_api_key
 
         self.api_usage_group.props.visible = False
-        if ProviderFeature.API_KEY_USAGE in self.provider.features:
+        if self.provider.supports_api_usage:
             create_background_task(self._load_api_usage())
 
     async def _load_api_usage(self):

--- a/dialect/window.blp
+++ b/dialect/window.blp
@@ -90,7 +90,7 @@ template $DialectWindow : Adw.ApplicationWindow {
 
               Button {
                 label: _("Retry");
-                clicked => $retry_load_translator();
+                clicked => $_on_retry_load_translator_clicked();
 
                 styles [
                   "pill",
@@ -113,7 +113,7 @@ template $DialectWindow : Adw.ApplicationWindow {
               orientation: vertical;
 
               Button error_retry_btn {
-                clicked => $retry_load_translator();
+                clicked => $_on_retry_load_translator_clicked();
 
                 styles [
                   "pill",
@@ -165,7 +165,7 @@ template $DialectWindow : Adw.ApplicationWindow {
               Button rmv_key_btn {
                 visible: false;
                 label: _("Remove Key and Retry");
-                clicked => $remove_key_and_reload();
+                clicked => $_on_remove_key_and_reload_clicked();
 
                 styles [
                   "pill",
@@ -189,7 +189,7 @@ template $DialectWindow : Adw.ApplicationWindow {
 
               Button error_api_key_btn {
                 visible: false;
-                clicked => $remove_key_and_reload();
+                clicked => $_on_remove_key_and_reload_clicked();
 
                 styles [
                   "pill",
@@ -240,7 +240,7 @@ template $DialectWindow : Adw.ApplicationWindow {
 
                   $LangSelector src_lang_selector {
                     notify::selected => $_on_src_lang_changed();
-                    user-selection-changed => $translation();
+                    user-selection-changed => $_on_translation();
                     tooltip-text: _("Change Source Language");
                   }
 
@@ -252,7 +252,7 @@ template $DialectWindow : Adw.ApplicationWindow {
 
                   $LangSelector dest_lang_selector {
                     notify::selected => $_on_dest_lang_changed();
-                    user-selection-changed => $translation();
+                    user-selection-changed => $_on_translation();
                     tooltip-text: _("Change Destination Language");
                   }
                 };
@@ -565,7 +565,7 @@ template $DialectWindow : Adw.ApplicationWindow {
                 selected: bind src_lang_selector.selected bidirectional;
                 tooltip-text: _("Change Source Language");
 
-                user-selection-changed => $translation();
+                user-selection-changed => $_on_translation();
               }
 
               [center]
@@ -581,7 +581,7 @@ template $DialectWindow : Adw.ApplicationWindow {
                 selected: bind dest_lang_selector.selected bidirectional;
                 tooltip-text: _("Change Destination Language");
 
-                user-selection-changed => $translation();
+                user-selection-changed => $_on_translation();
               }
             }
           }

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -226,8 +226,7 @@ class DialectWindow(Adw.ApplicationWindow):
         create_background_task(self.load_tts())
 
         # Listen to active providers changes
-        Settings.get().connect("translator-changed", self._on_active_provider_changed, "trans")
-        Settings.get().connect("tts-changed", self._on_active_provider_changed, "tts")
+        Settings.get().connect("provider-changed", self._on_active_provider_changed)
 
         # Bind text views font size
         self.src_text.bind_property("font-size", self.dest_text, "font-size", GObject.BindingFlags.BIDIRECTIONAL)
@@ -1192,10 +1191,10 @@ class DialectWindow(Adw.ApplicationWindow):
     def reload_translator(self):
         create_background_task(self.load_translator())
 
-    def _on_active_provider_changed(self, _settings: Gio.Settings, _provider: str, kind: str):
+    def _on_active_provider_changed(self, _settings: Settings, kind: str, _name: str):
         self.save_settings()
         match kind:
-            case "trans":
+            case "translator":
                 self.reload_translator()
             case "tts":
                 create_background_task(self.load_tts())

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -775,12 +775,9 @@ class DialectWindow(Adw.ApplicationWindow):
                 self.dest_buffer.get_start_iter(), self.dest_buffer.get_end_iter(), True
             )
             if translation := self.current_translation:
-                src, dest = self.provider["trans"].denormalize_lang(
-                    translation.original.src,
-                    translation.original.dest,
-                )
-
-                if await self.provider["trans"].suggest(translation.original.text, src, dest, dest_text):
+                if await self.provider["trans"].suggest(
+                    translation.original.text, translation.original.src, translation.original.dest, dest_text
+                ):
                     self.send_notification(_("New translation has been suggested!"))
                 else:
                     self.send_notification(_("Suggestion failed."))
@@ -854,8 +851,7 @@ class DialectWindow(Adw.ApplicationWindow):
             return
 
         try:
-            lang: str = self.provider["tts"].denormalize_lang(self.current_speech["lang"])  # type: ignore
-            speech_file = await self.provider["tts"].speech(self.current_speech["text"], lang)
+            speech_file = await self.provider["tts"].speech(self.current_speech["text"], self.current_speech["lang"])
 
             self._play_audio(speech_file.name)
             speech_file.close()
@@ -1119,10 +1115,7 @@ class DialectWindow(Adw.ApplicationWindow):
             self.next_translation = None
         else:
             text = self.src_buffer.get_text(self.src_buffer.get_start_iter(), self.src_buffer.get_end_iter(), True)
-            src, dest = self.provider["trans"].denormalize_lang(
-                self.src_lang_selector.selected, self.dest_lang_selector.selected
-            )
-            request = TranslationRequest(text, src, dest)
+            request = TranslationRequest(text, self.src_lang_selector.selected, self.dest_lang_selector.selected)
 
             if self.translation_loading:
                 self.next_translation = request


### PR DESCRIPTION
In this PR I'm experimenting with the recent [asyncio integration](https://gitlab.gnome.org/GNOME/pygobject/-/merge_requests/189) in PyGGbject.

On top of that I've made other refactors to make the new async code more clear and compact.

Aside from Soup's requests the only Gio async function we use is  `Gdk.Clipboard.read_text_async()`, ~~and I believe the current callback based code will be equally compact than using `create_background_task` so I'm not touching them for now~~ (With our `@background_task` decorator, that's not longer a problem). I also through about making an async version of `ProviderSettings.api_key` but I don't think is worth it for now.

After some testing everything seems pretty solid, but since it's an "experimental" feature we probably want to hold this as draft for some time.

## TODO

- [ ] Test providers APIs are working as expected 
  - [x] Translation
  - [x] TTS
  - [x] Suggestions 
  - [ ] API keys
    - [x] DeepL
    - [ ] LibreTranslate 
- [x] Port search provider




