### PR TITLE
window: `translate_selection`: Only get clipboard when window is active

### DIFF
--- a/dialect/main.py
+++ b/dialect/main.py
@@ -118,7 +118,7 @@ class Dialect(Adw.Application):
 
         if self.window is not None:
             if not text and selection:
-                self.window.translate_selection(langs["src"], langs["dest"])
+                self.window.queue_selection_translation(langs["src"], langs["dest"])
             elif text:
                 self.window.translate(text, langs["src"], langs["dest"])
 

--- a/dialect/window.blp
+++ b/dialect/window.blp
@@ -44,6 +44,8 @@ template $DialectWindow : Adw.ApplicationWindow {
   height-request: 320;
   focus-widget: src_text;
 
+  notify::is-active => $_on_is_active_changed();
+
   Adw.Breakpoint {
     condition ("max-width: 680px")
     setters {


### PR DESCRIPTION
Fixes #407