### PR TITLE
Add D-Bus service file

### DIFF
--- a/data/app.drey.Dialect.desktop.in.in
+++ b/data/app.drey.Dialect.desktop.in.in
@@ -4,6 +4,7 @@ Version=1.0
 Type=Application
 Terminal=false
 StartupNotify=true
+DBusActivatable=true
 Exec=dialect
 Name=Dialect
 Comment=Translate between languages

--- a/data/app.drey.Dialect.service.in
+++ b/data/app.drey.Dialect.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=@app-id@
+Exec=@bindir@/dialect --gapplication-service

--- a/data/meson.build
+++ b/data/meson.build
@@ -60,6 +60,18 @@ if compile_schemas.found()
   )
 endif
 
+# Install D-Bus service file
+service_conf = configuration_data()
+service_conf.set('app-id', application_id)
+service_conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
+configure_file(
+  input: '@0@.service.in'.format(base_id),
+  output: '@0@.service'.format(application_id),
+  configuration: service_conf,
+  install: true,
+  install_dir: join_paths(get_option('datadir'), 'dbus-1/services')
+)
+
 # Install colored icon
 install_data(
   '@0@.svg'.format(application_id),


### PR DESCRIPTION
And mark the application as D-Bus activatable. This allows application launchers to activate it via D-Bus.

Reference:
https://specifications.freedesktop.org/desktop-entry-spec/1.3/dbus.html