### PR TITLE
feat(providers/soup): Implement retries with exponential backoff

### DIFF
--- a/dialect/providers/modules/deepl.py
+++ b/dialect/providers/modules/deepl.py
@@ -35,6 +35,7 @@ class Provider(SoupProvider):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+        self.retry_errors = (429,)
         self.chars_limit = 5000
 
         # DeepL API Free keys can be identified by the suffix ":fx"
@@ -132,6 +133,8 @@ class Provider(SoupProvider):
                 raise APIKeyInvalid(message)
             case 456:
                 raise ServiceLimitReached(message)
+            case 429:
+                raise UnexpectedError("Too many requests!")
 
         if status != 200:
             raise UnexpectedError(message)


### PR DESCRIPTION
This is needed by the DeepL provider, and they recommend it in their API docs, since the service is expected to return "HTTP 429: too many requests" errors when sending many API requests in a short period of time.

https://developers.deepl.com/docs/best-practices/error-handling

Fixes #433 