### PR TITLE
docs: Clarify minimum PyGObject version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ sudo apt-get install dialect
 ### Requirements
 
 - Python 3 (>=3.10) `python`
-- PyGObject `python-gobject`
+- PyGObject (>=3.51.0) `python-gobject`
 - GTK4 (>= 4.16.0) `gtk4`
 - libadwaita (>= 1.6.0) `libadwaita`
 - libsoup (>= 3.0) `libsoup`


### PR DESCRIPTION
I tried updating the Dialect package in nixpkgs but ran into this error

```
AttributeError: 'Dialect' object has no attribute 'create_asyncio_task'
```

According to the [PyGObject changelog](https://pygobject.gnome.org/changelog.html), the Gio.Application [create_asyncio_task](https://github.com/dialect-app/dialect/blob/f78d6721d02f8e844b844b60a207b90e51f29161/dialect/asyncio.py#L20) method is added in PyGObject 3.51.0. I thought I'd document this for others.