### PR TITLE
Feat/OpenAI provider

### DIFF
--- a/data/app.drey.Dialect.gschema.xml.in
+++ b/data/app.drey.Dialect.gschema.xml.in
@@ -74,6 +74,20 @@
     </key>
   </schema>
 
+  <!-- OpenAI-compatible translator specific settings -->
+  <schema id="@app-id@.openai-translator" extends="@app-id@.translator">
+    <key type="s" name="model-name">
+      <default>"gpt-4o-mini"</default>
+    </key>
+    <key type="s" name="system-prompt">
+      <default>""</default>
+    </key>
+    <key type="d" name="temperature">
+      <default>0.3</default>
+      <range min="0.0" max="2.0"/>
+    </key>
+  </schema>
+
   <!-- TTS list schema -->
   <schema id="@app-id@.TTSList" extends="@app-id@.SettingsList">
     <override name="active">"google"</override>

--- a/dialect/providers/base.py
+++ b/dialect/providers/base.py
@@ -103,6 +103,8 @@ class BaseProvider:
     """ Translation language model """
     lang_comp: ProviderLangComparison = ProviderLangComparison.PLAIN
     """ Define behavior of default `cmp_langs` method """
+    settings_schema_id: str | None = None
+    """ Optional override for the provider's GSettings schema """
 
     defaults: ProviderDefaults = {
         "instance_url": "",
@@ -131,7 +133,7 @@ class BaseProvider:
         """ Here we save the translation history """
 
         # GSettings
-        self.settings = ProviderSettings(self.name, self.defaults)
+        self.settings = ProviderSettings(self.name, self.defaults, schema_id=self.settings_schema_id)
 
     """
     Providers API methods

--- a/dialect/providers/modules/openai_compatible.py
+++ b/dialect/providers/modules/openai_compatible.py
@@ -1,0 +1,251 @@
+# Copyright 2026 Dialect contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import re
+from typing import Any
+
+from gi.repository import Gio, GLib
+
+from dialect.define import APP_ID, LANGUAGES
+from dialect.providers.base import (
+    ProviderCapability,
+    ProviderFeature,
+    Translation,
+    TranslationRequest,
+)
+from dialect.providers.errors import (
+    APIKeyInvalid,
+    APIKeyRequired,
+    RequestError,
+    ServiceLimitReached,
+    UnexpectedError,
+)
+from dialect.providers.settings import ProviderDefaults
+from dialect.providers.soup import SoupProvider
+
+_DEFAULT_PROMPT = (
+    "You are a professional translator. "
+    "Translate the following text from {source_lang} to {target_lang}. "
+    "Output only the translation, no explanations."
+)
+_AUTO_DETECT_PROMPT = (
+    "You are a professional translator. "
+    "First detect the language of the input text, then translate it to {target_lang}. "
+    "Output only the translation, no explanations."
+)
+
+
+class Provider(SoupProvider):
+    name = "openai_compatible"
+    prettyname = "OpenAI Compatible"
+
+    capabilities = ProviderCapability.TRANSLATION
+    features = ProviderFeature.INSTANCES | ProviderFeature.API_KEY | ProviderFeature.DETECTION
+    settings_schema_id = f"{APP_ID}.openai-translator"
+
+    defaults: ProviderDefaults = {
+        "instance_url": "api.openai.com",
+        "api_key": "",
+        "src_langs": ["en", "zh-Hans", "ja", "fr", "es", "de"],
+        "dest_langs": ["zh-Hans", "en", "ja", "fr", "es", "de"],
+    }
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self.chars_limit = -1
+        self._current_cancellable: Gio.Cancellable | None = None
+
+    @property
+    def completions_url(self) -> str:
+        """OpenAI-compatible chat completions endpoint."""
+        return self._build_versioned_url("/chat/completions")
+
+    @property
+    def models_url(self) -> str:
+        """OpenAI-compatible models endpoint."""
+        return self._build_versioned_url("/models")
+
+    def _build_versioned_url(self, path: str, base_url: str | None = None) -> str:
+        """Build a full API URL, auto-appending `/v1` only when no version segment exists."""
+        url = (base_url or self.instance_url).rstrip("/")
+        if "/v1" not in url and not re.search(r"/v\d+", url):
+            url += "/v1"
+        return self.format_url(url, path)
+
+    async def init_trans(self) -> None:
+        """Populate translation languages from Dialect's static CLDR language list."""
+        for code in LANGUAGES:
+            self.add_lang(code)
+
+    async def validate_instance(self, url: str) -> bool:
+        """Validate the instance URL by probing the OpenAI-compatible models endpoint."""
+        test_url = self._build_versioned_url("/models", base_url=url)
+
+        headers: dict[str, str] = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        message = self.create_message("GET", test_url, headers=headers)
+        raw_response = await self.send_and_read_and_process(
+            message,
+            check_common=False,
+            return_json=False,
+        )
+        if message.get_status() in (401, 403):
+            return True
+
+        try:
+            response = json.loads(raw_response) if raw_response else {}
+        except json.JSONDecodeError:
+            return False
+        return isinstance(response, dict) and response.get("object") == "list" and "data" in response
+
+    async def validate_api_key(self, key: str) -> bool:
+        """Validate an API key against the configured models endpoint."""
+        if not key.strip():
+            return True
+
+        headers = {"Authorization": f"Bearer {key}"}
+        message = self.create_message("GET", self.models_url, headers=headers)
+        raw_response = await self.send_and_read_and_process(
+            message,
+            check_common=False,
+            return_json=False,
+        )
+        if message.get_status() in (401, 403):
+            return False
+        if message.get_status() < 200 or message.get_status() >= 300:
+            return False
+
+        try:
+            response = json.loads(raw_response) if raw_response else {}
+        except json.JSONDecodeError:
+            return False
+        return isinstance(response, dict)
+
+    def _get_lang_display_name(self, code: str) -> str:
+        """Return a human-readable language name, falling back to the language code."""
+        return self.get_lang_name(code) or code
+
+    def _append_missing_prompt_context(
+        self,
+        rendered_prompt: str,
+        template: str,
+        source_name: str,
+        target_name: str,
+    ) -> str:
+        context: list[str] = []
+        if "{source_lang}" not in template:
+            context.append(f"Source language: {source_name}")
+        if "{target_lang}" not in template:
+            context.append(f"Target language: {target_name}")
+        if not context:
+            return rendered_prompt
+        return f"{rendered_prompt}\n\n" + "\n".join(context)
+
+    def _build_system_prompt(self, request: TranslationRequest) -> str:
+        target_name = self._get_lang_display_name(request.dest)
+        source_name = (
+            "auto-detected language"
+            if request.src == "auto"
+            else self._get_lang_display_name(request.src)
+        )
+        custom_prompt = self.settings.system_prompt
+
+        if custom_prompt:
+            rendered_prompt = custom_prompt.replace("{source_lang}", source_name).replace(
+                "{target_lang}",
+                target_name,
+            )
+            return self._append_missing_prompt_context(rendered_prompt, custom_prompt, source_name, target_name)
+
+        if request.src == "auto":
+            return _AUTO_DETECT_PROMPT.format(target_lang=target_name)
+        return _DEFAULT_PROMPT.format(source_lang=source_name, target_lang=target_name)
+
+    def _build_messages(self, request: TranslationRequest) -> list[dict[str, str]]:
+        return [
+            {"role": "system", "content": self._build_system_prompt(request)},
+            {"role": "user", "content": request.text},
+        ]
+
+    def _cancel_ongoing(self) -> None:
+        """Cancel any in-flight request and prepare a cancellable for the next one."""
+        if self._current_cancellable and not self._current_cancellable.is_cancelled():
+            self._current_cancellable.cancel()
+        self._current_cancellable = Gio.Cancellable()
+
+    async def translate(self, request: TranslationRequest) -> Translation:
+        """Translate text through an OpenAI Chat Completions compatible endpoint."""
+        self._cancel_ongoing()
+        data: dict[str, Any] = {
+            "model": self.settings.model_name,
+            "messages": self._build_messages(request),
+        }
+        temperature = self.settings.temperature
+        if temperature is not None:
+            data["temperature"] = temperature
+
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        try:
+            response = await self.post(
+                self.completions_url,
+                data=data,
+                headers=headers,
+                cancellable=self._current_cancellable,
+            )
+        except GLib.Error as exc:
+            if exc.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED):
+                return Translation("", request)
+            raise
+
+        if not isinstance(response, dict):
+            raise UnexpectedError(f"Unexpected response type: {type(response)}")
+
+        choices = response.get("choices")
+        if not choices or not isinstance(choices, list):
+            raise UnexpectedError("No choices in response")
+
+        choice = choices[0]
+        if not isinstance(choice, dict):
+            raise UnexpectedError("Unexpected choice object in response")
+
+        message = choice.get("message")
+        if not isinstance(message, dict):
+            raise UnexpectedError("No message in response")
+
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise UnexpectedError("No content in response")
+
+        return Translation(content.strip(), request)
+
+    def check_known_errors(self, status: int, data: Any) -> None:
+        """Raise Dialect provider errors for OpenAI-compatible error responses."""
+        message = ""
+        if isinstance(data, dict):
+            error = data.get("error", {})
+            if isinstance(error, dict):
+                message = str(error.get("message", ""))
+            elif error:
+                message = str(error)
+
+        match status:
+            case 401:
+                if not self.api_key:
+                    raise APIKeyRequired(message)
+                raise APIKeyInvalid(message)
+            case 402 | 403:
+                raise APIKeyInvalid(message)
+            case 429:
+                raise ServiceLimitReached(message)
+
+        if status >= 500:
+            raise RequestError(message or f"HTTP {status}")
+        if status != 200:
+            raise UnexpectedError(message or f"HTTP {status}")

--- a/dialect/providers/settings.py
+++ b/dialect/providers/settings.py
@@ -30,8 +30,9 @@ class ProviderSettings(Gio.Settings):
     Helper class for providers settings
     """
 
-    def __init__(self, name: str, defaults: ProviderDefaults):
-        super().__init__(schema_id=f"{APP_ID}.translator", path=f"/app/drey/Dialect/translators/{name}/")
+    def __init__(self, name: str, defaults: ProviderDefaults, schema_id: str | None = None):
+        effective_schema = schema_id or f"{APP_ID}.translator"
+        super().__init__(schema_id=effective_schema, path=f"/app/drey/Dialect/translators/{name}/")
 
         self.name = name
         self.defaults = defaults  # set of per-provider defaults
@@ -110,3 +111,39 @@ class ProviderSettings(Gio.Settings):
     @dest_langs.setter
     def dest_langs(self, dest_langs: list[str]):
         self.set_strv("dest-langs", dest_langs)
+
+    @property
+    def model_name(self) -> str:
+        """Model name for OpenAI-compatible provider."""
+        try:
+            return self.get_string("model-name") or "gpt-4o-mini"
+        except GLib.Error:
+            return "gpt-4o-mini"
+
+    @model_name.setter
+    def model_name(self, value: str):
+        self.set_string("model-name", value)
+
+    @property
+    def system_prompt(self) -> str:
+        """Custom system prompt for OpenAI-compatible provider. Empty means use default."""
+        try:
+            return self.get_string("system-prompt")
+        except GLib.Error:
+            return ""
+
+    @system_prompt.setter
+    def system_prompt(self, value: str):
+        self.set_string("system-prompt", value)
+
+    @property
+    def temperature(self) -> float:
+        """Temperature for OpenAI-compatible provider."""
+        try:
+            return self.get_double("temperature")
+        except GLib.Error:
+            return 0.3
+
+    @temperature.setter
+    def temperature(self, value: float):
+        self.set_double("temperature", value)

--- a/dialect/providers/soup.py
+++ b/dialect/providers/soup.py
@@ -7,7 +7,7 @@ import logging
 from asyncio import sleep
 from typing import Any
 
-from gi.repository import GLib, Soup
+from gi.repository import Gio, GLib, Soup
 
 from dialect.providers.base import BaseProvider
 from dialect.providers.errors import RequestError
@@ -80,30 +80,32 @@ class SoupProvider(BaseProvider):
 
         return message  # type: ignore
 
-    async def send_and_read(self, message: Soup.Message) -> bytes | None:
+    async def send_and_read(self, message: Soup.Message, cancellable: Gio.Cancellable | None = None) -> bytes | None:
         """
         Helper method for Soup's send_and_read_async.
 
         Args:
             message: Message to send.
+            cancellable: Optional cancellable used to abort the request.
 
         Returns:
             The bytes of the response or None.
         """
-        response: GLib.Bytes = await Session.get().send_and_read_async(message, 0)  # type: ignore
+        response: GLib.Bytes = await Session.get().send_and_read_async(message, 0, cancellable)  # type: ignore
         return response.get_data()
 
-    async def send_and_read_json(self, message: Soup.Message) -> Any:
+    async def send_and_read_json(self, message: Soup.Message, cancellable: Gio.Cancellable | None = None) -> Any:
         """
         Like ``SoupProvider.send_and_read`` but returns JSON parsed.
 
         Args:
             message: Message to send.
+            cancellable: Optional cancellable used to abort the request.
 
         Returns:
             The JSON of the response deserialized to a python object.
         """
-        response = await self.send_and_read(message)
+        response = await self.send_and_read(message, cancellable)
         return json.loads(response) if response else {}
 
     def check_known_errors(self, status: Soup.Status, data: Any) -> None:
@@ -122,6 +124,7 @@ class SoupProvider(BaseProvider):
         message: Soup.Message,
         check_common: bool = True,
         return_json: bool = True,
+        cancellable: Gio.Cancellable | None = None,
     ) -> Any:
         """
         Helper mixing ``SoupProvider.send_and_read``, ``SoupProvider.send_and_read_json``
@@ -135,6 +138,7 @@ class SoupProvider(BaseProvider):
             message: Message to send.
             check_common: If response data should be checked for errors using check_known_errors.
             return_json: If the response should be parsed as JSON.
+            cancellable: Optional cancellable used to abort the request.
 
         Returns:
             The JSON deserialized to a python object or bytes if ``json`` is ``False``.
@@ -142,9 +146,9 @@ class SoupProvider(BaseProvider):
 
         async def send_and_read() -> Any:
             if return_json:
-                return await self.send_and_read_json(message)
+                return await self.send_and_read_json(message, cancellable)
             else:
-                return await self.send_and_read(message)
+                return await self.send_and_read(message, cancellable)
 
         try:
             response = await send_and_read()
@@ -167,6 +171,8 @@ class SoupProvider(BaseProvider):
 
             return response
         except GLib.Error as exc:
+            if exc.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED):
+                raise
             raise RequestError(exc.message)
 
     async def request(
@@ -178,6 +184,7 @@ class SoupProvider(BaseProvider):
         form: bool = False,
         check_common: bool = True,
         return_json: bool = True,
+        cancellable: Gio.Cancellable | None = None,
     ) -> Any:
         """
         Helper for regular HTTP request.
@@ -190,12 +197,13 @@ class SoupProvider(BaseProvider):
             form: If the data should be encoded as a form.
             check_common: If response data should be checked for errors using check_known_errors.
             return_json: If the response should be parsed as JSON.
+            cancellable: Optional cancellable used to abort the request.
 
         Returns:
             The JSON deserialized to a python object or bytes if ``json`` is ``False``.
         """
         message = self.create_message(method, url, data, headers, form)
-        return await self.send_and_read_and_process(message, check_common, return_json)
+        return await self.send_and_read_and_process(message, check_common, return_json, cancellable)
 
     async def get(
         self,
@@ -203,6 +211,7 @@ class SoupProvider(BaseProvider):
         headers: dict = {},
         check_common: bool = True,
         return_json: bool = True,
+        cancellable: Gio.Cancellable | None = None,
     ) -> Any:
         """
         Helper for GET HTTP request.
@@ -212,11 +221,19 @@ class SoupProvider(BaseProvider):
             headers: HTTP headers of the message.
             check_common: If response data should be checked for errors using check_known_errors.
             return_json: If the response should be parsed as JSON.
+            cancellable: Optional cancellable used to abort the request.
 
         Returns:
             The JSON deserialized to a python object or bytes if ``json`` is ``False``.
         """
-        return await self.request("GET", url, headers=headers, check_common=check_common, return_json=return_json)
+        return await self.request(
+            "GET",
+            url,
+            headers=headers,
+            check_common=check_common,
+            return_json=return_json,
+            cancellable=cancellable,
+        )
 
     async def post(
         self,
@@ -226,6 +243,7 @@ class SoupProvider(BaseProvider):
         form: bool = False,
         check_common: bool = True,
         return_json: bool = True,
+        cancellable: Gio.Cancellable | None = None,
     ) -> Any:
         """
         Helper for POST HTTP request.
@@ -237,8 +255,18 @@ class SoupProvider(BaseProvider):
             form: If the data should be encoded as a form.
             check_common: If response data should be checked for errors using check_known_errors.
             return_json: If the response should be parsed as JSON.
+            cancellable: Optional cancellable used to abort the request.
 
         Returns:
             The JSON deserialized to a python object or bytes if ``json`` is ``False``.
         """
-        return await self.request("POST", url, data, headers, form, check_common, return_json)
+        return await self.request(
+            "POST",
+            url,
+            data=data,
+            headers=headers,
+            form=form,
+            check_common=check_common,
+            return_json=return_json,
+            cancellable=cancellable,
+        )

--- a/dialect/widgets/provider_preferences.blp
+++ b/dialect/widgets/provider_preferences.blp
@@ -97,6 +97,58 @@ template $ProviderPreferences : Adw.NavigationPage {
         }
 
       }
+
+      Adw.PreferencesGroup advanced_group {
+        title: _("Advanced Options");
+        visible: false;
+
+        Adw.EntryRow model_name_entry {
+          title: _("Model Name");
+          tooltip-text: _("e.g. gpt-4o-mini, gpt-4o, deepseek-chat");
+          show-apply-button: true;
+
+          apply => $_on_model_name_apply();
+        }
+
+        Adw.SpinRow temperature_spin {
+          title: _("Temperature");
+          subtitle: _("Lower values produce more consistent translations. Recommended: 0.3");
+
+          adjustment: Gtk.Adjustment {
+            lower: 0.0;
+            upper: 2.0;
+            step-increment: 0.1;
+            page-increment: 0.5;
+            value: 0.3;
+          };
+        }
+
+        Adw.ExpanderRow system_prompt_expander {
+          title: _("Custom System Prompt");
+          subtitle: _("Use {source_lang} and {target_lang} as placeholders");
+
+          Adw.EntryRow system_prompt_entry {
+            title: _("System Prompt");
+            tooltip-text: _("Leave empty for the default prompt template");
+            show-apply-button: true;
+
+            apply => $_on_system_prompt_apply();
+          }
+
+          Adw.ActionRow {
+            title: _("Reset System Prompt");
+
+            [suffix]
+            Button system_prompt_reset {
+              label: _("Reset to Default");
+              tooltip-text: _("Reset system prompt to default template");
+              valign: center;
+
+              clicked => $_on_reset_system_prompt();
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/dialect/widgets/provider_preferences.py
+++ b/dialect/widgets/provider_preferences.py
@@ -39,6 +39,11 @@ class ProviderPreferences(Adw.NavigationPage):
     api_usage_group: Adw.PreferencesGroup = Gtk.Template.Child()  # type: ignore
     api_usage: Gtk.LevelBar = Gtk.Template.Child()  # type: ignore
     api_usage_label: Gtk.Label = Gtk.Template.Child()  # type: ignore
+    advanced_group: Adw.PreferencesGroup = Gtk.Template.Child()  # type: ignore
+    model_name_entry: Adw.EntryRow = Gtk.Template.Child()  # type: ignore
+    temperature_spin: Adw.SpinRow = Gtk.Template.Child()  # type: ignore
+    system_prompt_expander: Adw.ExpanderRow = Gtk.Template.Child()  # type: ignore
+    system_prompt_entry: Adw.EntryRow = Gtk.Template.Child()  # type: ignore
 
     def __init__(self, scope: str, dialog: Adw.PreferencesDialog, window: DialectWindow, **kwargs):
         super().__init__(**kwargs)
@@ -57,10 +62,13 @@ class ProviderPreferences(Adw.NavigationPage):
 
             # Check what entries to show
             self._check_settings()
+            self._check_advanced_options()
 
             # Load saved values
             self.instance_entry.props.text = self.provider.instance_url
             self.api_key_entry.props.text = self.provider.api_key
+
+        self.temperature_spin.get_adjustment().connect("value-changed", self._on_temperature_changed)
 
         # Main window progress
         self.window.connect("notify::translator-loading", self._on_translator_loading)
@@ -75,6 +83,20 @@ class ProviderPreferences(Adw.NavigationPage):
         self.api_usage_group.props.visible = False
         if self.provider.supports_api_usage:
             self._load_api_usage()
+
+    def _check_advanced_options(self):
+        """Show OpenAI-compatible advanced settings when applicable."""
+        if not self.provider:
+            self.advanced_group.props.visible = False
+            return
+
+        self.advanced_group.props.visible = self.provider.name == "openai_compatible"
+        if self.provider.name != "openai_compatible":
+            return
+
+        self.model_name_entry.props.text = self.provider.settings.model_name
+        self.temperature_spin.set_value(self.provider.settings.temperature)
+        self.system_prompt_entry.props.text = self.provider.settings.system_prompt
 
     @background_task
     async def _load_api_usage(self):
@@ -209,9 +231,63 @@ class ProviderPreferences(Adw.NavigationPage):
         self.api_key_entry.remove_css_class("error")
         self.api_key_entry.props.text = self.provider.api_key
 
+    @Gtk.Template.Callback()
+    def _on_model_name_apply(self, _row):
+        """Called on self.model_name_entry::apply signal"""
+        if not self.provider or self.provider.name != "openai_compatible":
+            return
+
+        model_name = self.model_name_entry.props.text.strip()
+        if model_name:
+            self.provider.settings.model_name = model_name
+            return
+
+        self.model_name_entry.props.text = self.provider.settings.model_name
+
+    def _on_temperature_changed(self, _adjustment):
+        """Called on self.temperature_spin adjustment::value-changed signal."""
+        if not self.provider or self.provider.name != "openai_compatible":
+            return
+
+        self.provider.settings.temperature = self.temperature_spin.get_value()
+
+    @Gtk.Template.Callback()
+    def _on_system_prompt_apply(self, _row):
+        """Called on self.system_prompt_entry::apply signal"""
+        if not self.provider or self.provider.name != "openai_compatible":
+            return
+
+        custom_prompt = self.system_prompt_entry.props.text
+        self.provider.settings.system_prompt = custom_prompt
+
+        missing = [
+            placeholder
+            for placeholder in ("{source_lang}", "{target_lang}")
+            if placeholder not in custom_prompt
+        ]
+        if custom_prompt and missing:
+            placeholders = ", ".join(missing)
+            toast = Adw.Toast(
+                title=_("Prompt missing {placeholders}; language context will be appended automatically").format(
+                    placeholders=placeholders,
+                )
+            )
+            self.dialog.add_toast(toast)
+
+    @Gtk.Template.Callback()
+    def _on_reset_system_prompt(self, _button):
+        """Called on system_prompt_reset::clicked signal"""
+        if not self.provider or self.provider.name != "openai_compatible":
+            return
+
+        self.provider.settings.system_prompt = ""
+        self.system_prompt_entry.props.text = ""
+        self.system_prompt_entry.remove_css_class("error")
+
     def _on_translator_loading(self, window: DialectWindow, _value):
         self.page.props.sensitive = not window.translator_loading
 
         if not window.translator_loading:
             self.provider = self.window.provider[self.scope]
             self._check_settings()
+            self._check_advanced_options()

--- a/dialect/window.py
+++ b/dialect/window.py
@@ -782,6 +782,8 @@ class DialectWindow(Adw.ApplicationWindow):
         self.dest_lang_selector.button.popup()
 
     def _on_clear_action(self, *_args):
+        if self.provider["trans"] and hasattr(self.provider["trans"], "_cancel_ongoing"):
+            self.provider["trans"]._cancel_ongoing()
         self.src_buffer.props.text = ""
         self.src_buffer.emit("end-user-action")
 
@@ -1150,6 +1152,8 @@ class DialectWindow(Adw.ApplicationWindow):
             request = TranslationRequest(text, self.src_lang_selector.selected, self.dest_lang_selector.selected)
 
             if self.translation_loading:
+                if hasattr(self.provider["trans"], "_cancel_ongoing"):
+                    self.provider["trans"]._cancel_ongoing()
                 self.next_translation = request
                 return
 
@@ -1164,6 +1168,9 @@ class DialectWindow(Adw.ApplicationWindow):
 
             try:
                 translation = await self.provider["trans"].translate(request)
+
+                if translation.text == "" and request.text != "":
+                    return
 
                 if translation.detected and self.src_lang_selector.selected == "auto":
                     if Settings.get().src_auto:
@@ -1184,6 +1191,17 @@ class DialectWindow(Adw.ApplicationWindow):
 
             # Translation failed
             except (RequestError, ProviderError) as exc:
+                provider = self.provider["trans"]
+                logging.error(
+                    "Translation failed with provider error",
+                    exc_info=exc,
+                    extra={
+                        "provider_name": provider.name if provider else None,
+                        "provider_prettyname": provider.prettyname if provider else None,
+                        "provider_instance_url": provider.instance_url if provider and provider.supports_instances else None,
+                        "error_type": type(exc).__name__,
+                    },
+                )
                 self.trans_warning.props.visible = True
                 self.lookup_action("copy").props.enabled = False  # type: ignore
                 self.lookup_action("listen-src").props.enabled = False  # type: ignore

--- a/uv.lock
+++ b/uv.lock
@@ -159,8 +159,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pygobject-stubs", specifier = ">=2.16.0" },
-    { name = "ruff", specifier = ">=0.14.9" },
-    { name = "ty", specifier = ">=0.0.1a34" },
+    { name = "ruff", specifier = ">=0.14.11" },
+    { name = "ty", specifier = ">=0.0.11" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request adds support for OpenAI-compatible translation providers to Dialect, allowing users to configure and use models such as GPT-4o or other compatible endpoints. The implementation introduces a new provider module, extends the settings infrastructure to support model-specific options, and updates the UI to expose advanced configuration options for these providers.

Key changes:

**1. OpenAI-Compatible Provider Implementation**
- Added a new provider module `openai_compatible.py` that implements translation using OpenAI-compatible chat completions APIs, including support for custom system prompts, temperature, and model selection. This provider handles API key validation, instance validation, language detection, and error handling specific to OpenAI endpoints.

**2. Settings Infrastructure Enhancements**
- Introduced a new GSettings schema (`@app-id@.openai-translator`) with keys for `model-name`, `system-prompt`, and `temperature` to store provider-specific options.
- Updated `ProviderSettings` and its usage to allow specifying a custom schema ID, enabling per-provider settings. Added properties and setters for the new OpenAI options. 

**3. Provider Base and SoupProvider Improvements**
- Updated the `BaseProvider` class to allow specifying a settings schema ID for greater flexibility.
- Enhanced the `SoupProvider` class and its HTTP helpers to support request cancellation via `Gio.Cancellable`, which is used by the new provider to cancel in-flight requests. 

**4. User Interface Updates**
- Extended the provider preferences UI (`provider_preferences.blp`) to add an "Advanced Options" group, exposing fields for model name, temperature, and custom system prompt for OpenAI-compatible providers, including reset and apply actions.